### PR TITLE
increase sprungMass

### DIFF
--- a/addons/UH60/config/cfgVehicles.hpp
+++ b/addons/UH60/config/cfgVehicles.hpp
@@ -332,7 +332,7 @@ class CfgVehicles
                 maxCompression				= 0.2;
                 maxDroop					= 0.05;
 
-                sprungMass					= 4000;
+                sprungMass					= 6000;
                 springStrength				= 90000;
                 springDamperRate			= 4000;
 
@@ -353,6 +353,7 @@ class CfgVehicles
                 tireForceAppPointOffset		= "wheel_1_2_center";
                 center						= "wheel_1_2_center";
                 boundary					= "wheel_1_2_rim";
+                sprungMass					= 8500;
             };
             class Wheel_3: Wheel_2
             {


### PR DESCRIPTION
Close #9
increased `sprungMass` of front wheels to sum to roughly vehicle mass in Geometry LOD, right one seems to need to be stronger due to probe mass?
https://youtu.be/iODahl7QzwE