### PR TITLE
Keybind safety

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -11,3 +11,5 @@ class name { \
 
 //#undef PREP
 //#define PREP(var1) TRIPLES(ADDON,fnc,var1) = { call compile preProcessFileLineNumbers '\MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT_F\functions\DOUBLES(fnc,var1).sqf' }
+
+#define ZEUS_EXIT if !(isNull curatorCamera) exitWith {};

--- a/addons/uh60_fd/initKeybinds.sqf
+++ b/addons/uh60_fd/initKeybinds.sqf
@@ -3,6 +3,7 @@
   "vtx_uh60m_c_rmtsby",
   LSTRING(Standby),
   {},{
+    ZEUS_EXIT
     private _vehicle = vehicle player;
     if ([_vehicle, "ui", "vtx_H60_base"] call vxf_core_fnc_hasModule) then {
       [_vehicle, "STBY"] call vtx_uh60_fd_fnc_modeSet;
@@ -17,6 +18,7 @@
   "vtx_uh60_fd_raltToggle",
   LSTRING(RALTToggle),
   {},{
+    ZEUS_EXIT
     private _vehicle = vehicle player;
     if ([_vehicle, "ui", "vtx_H60_base"] call vxf_core_fnc_hasModule) then {
       [vehicle player, "RALT"] call vtx_uh60_fd_fnc_modeSet;

--- a/addons/uh60_fd/initKeybinds.sqf
+++ b/addons/uh60_fd/initKeybinds.sqf
@@ -1,25 +1,25 @@
 [
-    "UH-60M Blackhawk",
-    "vtx_uh60m_c_rmtsby",
-    LSTRING(Standby),
-    {},{
-        private _vehicle = vehicle player;
-        if ([_vehicle, "ui", "vtx_H60_base"] call vxf_core_fnc_hasModule) then {
-            [_vehicle, "STBY"] call vtx_uh60_fd_fnc_modeSet;
-        };
-    },
-    [15, [false, true, false]],
-    false
+  "UH-60M Blackhawk",
+  "vtx_uh60m_c_rmtsby",
+  LSTRING(Standby),
+  {},{
+    private _vehicle = vehicle player;
+    if ([_vehicle, "ui", "vtx_H60_base"] call vxf_core_fnc_hasModule) then {
+      [_vehicle, "STBY"] call vtx_uh60_fd_fnc_modeSet;
+    };
+  },
+  [15, [false, true, false]],
+  false
 ] call CBA_fnc_addKeybind;
 
 [
-    "UH-60M Blackhawk",
-    "vtx_uh60_fd_raltToggle",
-    LSTRING(RALTToggle),
-    {},{
-        private _vehicle = vehicle player;
-        if ([_vehicle, "ui", "vtx_H60_base"] call vxf_core_fnc_hasModule) then {
-            [vehicle player, "RALT"] call vtx_uh60_fd_fnc_modeSet;
-        };
-    }
+  "UH-60M Blackhawk",
+  "vtx_uh60_fd_raltToggle",
+  LSTRING(RALTToggle),
+  {},{
+    private _vehicle = vehicle player;
+    if ([_vehicle, "ui", "vtx_H60_base"] call vxf_core_fnc_hasModule) then {
+      [vehicle player, "RALT"] call vtx_uh60_fd_fnc_modeSet;
+    };
+  }
 ] call CBA_fnc_addKeybind;


### PR DESCRIPTION
**When merged this pull request will:**
- Add `ZEUS_EXIT` macro
- Stop Flight Director keybinds from working in Zeus