### PR TITLE
Bugfix/hook teleporting to 0000

### DIFF
--- a/addons/uh60_hoist/functions/fnc_deployHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_deployHook.sqf
@@ -35,6 +35,10 @@ _rope = ropeCreate [_heli, _hoistPos, _dummy, [0,0,0], 0.5];
 _heli setVariable ["vtx_uh60_hoist_vars", [_rope, _dummy, _hook], true];
 _hook setVariable ["vtx_uh60_hoist_heli", _heli, true];
 
+// This should fix the hook teleport issue. - Fawks
+_rope allowDamage false;
+_hook allowDamage false;
+
 // handle rope break
 _heli addEventHandler ["RopeBreak",{
     params ["_heli", "_rope", "_dummy"];

--- a/addons/uh60_hoist/functions/fnc_raiseHookToHeli.sqf
+++ b/addons/uh60_hoist/functions/fnc_raiseHookToHeli.sqf
@@ -21,6 +21,27 @@ _hoist_vars params ["_rope", "_dummy", "_hook"];
 
 _hoistPos = [1.405, 2.03, 0.45];
 ropeUnwind [_rope, 1.5, 0.5];
+
+
+// Added by Fawks
+// Monitor the hook while it is being raised.
+// If the hook goes underground teleport it above ground.
+
+[_rope, _hook] spawn {
+  params ["_rope", "_hook"];
+  waitUntil {
+    _hookPos = getPosATL _hook;
+    if ((_hookPos # 2) > 10) then {
+      true
+    } else {
+      if ((_hookPos) # 2 < 0) then {
+        _hook setPos [_hookPos # 0, _hookPos # 1, 5];
+      };
+      sleep 1;
+      false
+    };
+  };
+};
 /*
 [{
 	params ["_heli", "_hoistPos", "_dummy", "_rope"];


### PR DESCRIPTION
**Attempt to fix the hook teleport - number 2**
- Make the hoist hook unbreakable.
- Add a tracker when the hook is being raised to monitor the hook's Z-axis. And correct it if it goes below 0.
