### PR TITLE
Feature/Added option to disable systemChat messages

### DIFF
--- a/addons/uh60_acre/functions/fnc_setRadioVolume.sqf
+++ b/addons/uh60_acre/functions/fnc_setRadioVolume.sqf
@@ -14,7 +14,7 @@ private _racks = [_vehicle] call acre_sys_rack_fnc_getVehicleRacks;
 private _radio = [_racks # _index] call acre_sys_rack_fnc_getMountedRadio;
 private _activeRadios = [] call acre_api_fnc_getCurrentRadioList;
 
-if(vtx_uh60m_trackIR_interaction_systemChat) then {
+if(vtx_uh60_hui_showDebugMessages) then {
     systemChat str [
         [_radio, player] call acre_sys_rack_fnc_isRadioAccessible,
         [_radio, player] call acre_sys_rack_fnc_isRadioHearable

--- a/addons/uh60_acre/functions/fnc_setRadioVolume.sqf
+++ b/addons/uh60_acre/functions/fnc_setRadioVolume.sqf
@@ -14,7 +14,7 @@ private _racks = [_vehicle] call acre_sys_rack_fnc_getVehicleRacks;
 private _radio = [_racks # _index] call acre_sys_rack_fnc_getMountedRadio;
 private _activeRadios = [] call acre_api_fnc_getCurrentRadioList;
 
-if(vtx_uh60_hui_showDebugMessages) then {
+if(vtx_uh60_ui_showDebugMessages) then {
     systemChat str [
         [_radio, player] call acre_sys_rack_fnc_isRadioAccessible,
         [_radio, player] call acre_sys_rack_fnc_isRadioHearable

--- a/addons/uh60_acre/functions/fnc_setRadioVolume.sqf
+++ b/addons/uh60_acre/functions/fnc_setRadioVolume.sqf
@@ -14,10 +14,12 @@ private _racks = [_vehicle] call acre_sys_rack_fnc_getVehicleRacks;
 private _radio = [_racks # _index] call acre_sys_rack_fnc_getMountedRadio;
 private _activeRadios = [] call acre_api_fnc_getCurrentRadioList;
 
-systemChat str [
-    [_radio, player] call acre_sys_rack_fnc_isRadioAccessible,
-    [_radio, player] call acre_sys_rack_fnc_isRadioHearable
-];
+if(vtx_uh60m_trackIR_interaction_systemChat) then {
+    systemChat str [
+        [_radio, player] call acre_sys_rack_fnc_isRadioAccessible,
+        [_radio, player] call acre_sys_rack_fnc_isRadioHearable
+    ];
+};
 
 [_radio, _value] call acre_sys_radio_fnc_setRadioVolume;
 if (_value == 0 && (_radio in _activeRadios)) then {

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -18,7 +18,7 @@ if(
 ) exitWith {
     _vehicle setVariable ["ENG1_PWR", 0, true];
     _vehicle setVariable ["ENG2_PWR", 0, true];
-    systemChat "damage start cancel";
+    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "damage start cancel";};
     _vehicle engineOn false;
 };
 
@@ -66,6 +66,6 @@ if (_fuelFlow2 > 0) then {
 _turnedOn = (_power > 0);
 
 _vehicle engineOn _turnedOn;
-systemChat "ENGINE STATE CHANGE";
+if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "ENGINE STATE CHANGE";};
 _this call vtx_uh60_engine_fnc_batteryState;
 [_vehicle] call vtx_uh60_cas_fnc_updateCautionPanel;

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -18,7 +18,7 @@ if(
 ) exitWith {
     _vehicle setVariable ["ENG1_PWR", 0, true];
     _vehicle setVariable ["ENG2_PWR", 0, true];
-    if(vtx_uh60_hui_showDebugMessages) then {systemChat "damage start cancel";};
+    if(vtx_uh60_ui_showDebugMessages) then {systemChat "damage start cancel";};
     _vehicle engineOn false;
 };
 
@@ -66,6 +66,6 @@ if (_fuelFlow2 > 0) then {
 _turnedOn = (_power > 0);
 
 _vehicle engineOn _turnedOn;
-if(vtx_uh60_hui_showDebugMessages) then {systemChat "ENGINE STATE CHANGE";};
+if(vtx_uh60_ui_showDebugMessages) then {systemChat "ENGINE STATE CHANGE";};
 _this call vtx_uh60_engine_fnc_batteryState;
 [_vehicle] call vtx_uh60_cas_fnc_updateCautionPanel;

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -18,7 +18,7 @@ if(
 ) exitWith {
     _vehicle setVariable ["ENG1_PWR", 0, true];
     _vehicle setVariable ["ENG2_PWR", 0, true];
-    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "damage start cancel";};
+    if(vtx_uh60_hui_showDebugMessages) then {systemChat "damage start cancel";};
     _vehicle engineOn false;
 };
 
@@ -66,6 +66,6 @@ if (_fuelFlow2 > 0) then {
 _turnedOn = (_power > 0);
 
 _vehicle engineOn _turnedOn;
-if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "ENGINE STATE CHANGE";};
+if(vtx_uh60_hui_showDebugMessages) then {systemChat "ENGINE STATE CHANGE";};
 _this call vtx_uh60_engine_fnc_batteryState;
 [_vehicle] call vtx_uh60_cas_fnc_updateCautionPanel;

--- a/addons/uh60_engine/functions/fnc_hasFuelFlow.sqf
+++ b/addons/uh60_engine/functions/fnc_hasFuelFlow.sqf
@@ -21,7 +21,7 @@ if (_isCrossFeed && !(_boosterEnabled)) then {_fuelFlow = _fuelFlow / 2};
 if (_altASLKFt > 5 && !(_boosterEnabled)) then {
     private _altOverMin = (_altASLKFt - 5);
     private _altDivision = (_altOverMin / 2) max 1;
-    systemChat str [_altOverMin, _altDivision];
+    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str [_altOverMin, _altDivision];};
     _fuelFlow = _fuelFlow / _altDivision;
 };
 

--- a/addons/uh60_engine/functions/fnc_hasFuelFlow.sqf
+++ b/addons/uh60_engine/functions/fnc_hasFuelFlow.sqf
@@ -21,7 +21,7 @@ if (_isCrossFeed && !(_boosterEnabled)) then {_fuelFlow = _fuelFlow / 2};
 if (_altASLKFt > 5 && !(_boosterEnabled)) then {
     private _altOverMin = (_altASLKFt - 5);
     private _altDivision = (_altOverMin / 2) max 1;
-    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str [_altOverMin, _altDivision];};
+    if(vtx_uh60_hui_showDebugMessages) then {systemChat str [_altOverMin, _altDivision];};
     _fuelFlow = _fuelFlow / _altDivision;
 };
 

--- a/addons/uh60_engine/functions/fnc_hasFuelFlow.sqf
+++ b/addons/uh60_engine/functions/fnc_hasFuelFlow.sqf
@@ -21,7 +21,7 @@ if (_isCrossFeed && !(_boosterEnabled)) then {_fuelFlow = _fuelFlow / 2};
 if (_altASLKFt > 5 && !(_boosterEnabled)) then {
     private _altOverMin = (_altASLKFt - 5);
     private _altDivision = (_altOverMin / 2) max 1;
-    if(vtx_uh60_hui_showDebugMessages) then {systemChat str [_altOverMin, _altDivision];};
+    if(vtx_uh60_ui_showDebugMessages) then {systemChat str [_altOverMin, _altDivision];};
     _fuelFlow = _fuelFlow / _altDivision;
 };
 

--- a/addons/uh60_engine/functions/fnc_starterState.sqf
+++ b/addons/uh60_engine/functions/fnc_starterState.sqf
@@ -34,7 +34,7 @@ if (_temp > -55 && _temp < 52) then {
     _canStartTwin = _underTwinStartSlope && _underTwinStartLimit && _airFlow;
 };
 
-if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str [_canStartSingle, _canStartTwin];};
+if(vtx_uh60_hui_showDebugMessages) then {systemChat str [_canStartSingle, _canStartTwin];};
 
 if (_animName == "STARTER1") then {
     if((_vehicle getVariable ["ENG_START2", false] && _canStartSingle) || _canStartTwin) then {

--- a/addons/uh60_engine/functions/fnc_starterState.sqf
+++ b/addons/uh60_engine/functions/fnc_starterState.sqf
@@ -34,7 +34,7 @@ if (_temp > -55 && _temp < 52) then {
     _canStartTwin = _underTwinStartSlope && _underTwinStartLimit && _airFlow;
 };
 
-if(vtx_uh60_hui_showDebugMessages) then {systemChat str [_canStartSingle, _canStartTwin];};
+if(vtx_uh60_ui_showDebugMessages) then {systemChat str [_canStartSingle, _canStartTwin];};
 
 if (_animName == "STARTER1") then {
     if((_vehicle getVariable ["ENG_START2", false] && _canStartSingle) || _canStartTwin) then {

--- a/addons/uh60_engine/functions/fnc_starterState.sqf
+++ b/addons/uh60_engine/functions/fnc_starterState.sqf
@@ -34,7 +34,7 @@ if (_temp > -55 && _temp < 52) then {
     _canStartTwin = _underTwinStartSlope && _underTwinStartLimit && _airFlow;
 };
 
-systemChat str [_canStartSingle, _canStartTwin];
+if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str [_canStartSingle, _canStartTwin];};
 
 if (_animName == "STARTER1") then {
     if((_vehicle getVariable ["ENG_START2", false] && _canStartSingle) || _canStartTwin) then {

--- a/addons/uh60_fd/functions/fnc_alt.sqf
+++ b/addons/uh60_fd/functions/fnc_alt.sqf
@@ -21,7 +21,7 @@ if ((abs _altDiff) > 3) then {
     };
     vtx_uh60_fd_lastAltMatch = false;
     private _timeSinceChange = cba_missionTime - vtx_uh60_fd_lastAltChangeTime;
-    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _timeSinceChange;};
+    if(vtx_uh60_hui_showDebugMessages) then {systemChat str _timeSinceChange;};
     _verticalVelocityGoal = (_altDiff max -1 min 1) * (if (_timeSinceChange < 5) then [{1.21}, {4.87}]);
 } else {
     vtx_uh60_fd_lastAltMatch = true;

--- a/addons/uh60_fd/functions/fnc_alt.sqf
+++ b/addons/uh60_fd/functions/fnc_alt.sqf
@@ -21,7 +21,7 @@ if ((abs _altDiff) > 3) then {
     };
     vtx_uh60_fd_lastAltMatch = false;
     private _timeSinceChange = cba_missionTime - vtx_uh60_fd_lastAltChangeTime;
-    if(vtx_uh60_hui_showDebugMessages) then {systemChat str _timeSinceChange;};
+    if(vtx_uh60_ui_showDebugMessages) then {systemChat str _timeSinceChange;};
     _verticalVelocityGoal = (_altDiff max -1 min 1) * (if (_timeSinceChange < 5) then [{1.21}, {4.87}]);
 } else {
     vtx_uh60_fd_lastAltMatch = true;

--- a/addons/uh60_fd/functions/fnc_alt.sqf
+++ b/addons/uh60_fd/functions/fnc_alt.sqf
@@ -21,7 +21,7 @@ if ((abs _altDiff) > 3) then {
     };
     vtx_uh60_fd_lastAltMatch = false;
     private _timeSinceChange = cba_missionTime - vtx_uh60_fd_lastAltChangeTime;
-    systemChat str _timeSinceChange;
+    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _timeSinceChange;};
     _verticalVelocityGoal = (_altDiff max -1 min 1) * (if (_timeSinceChange < 5) then [{1.21}, {4.87}]);
 } else {
     vtx_uh60_fd_lastAltMatch = true;

--- a/addons/uh60_fd/functions/fnc_modeSet.sqf
+++ b/addons/uh60_fd/functions/fnc_modeSet.sqf
@@ -22,28 +22,32 @@ switch (_mode) do {
         SET_GLOBAL("roll_mode",nil);
     };
     case "RALT": {
-        CYCLE_RALT_STATE; systemChat str ["RALT", GET_RALT_STATE];
+        CYCLE_RALT_STATE; 
+        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["RALT", GET_RALT_STATE];};
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);
         SET_VS_STATE(false);
         if (GET_RALT_STATE) then {SET_GLOBAL("alt_mode",vtx_uh60_fd_fnc_ralt)}else{SET_GLOBAL("alt_mode",nil)};
     };
     case "ALT": {
-        CYCLE_ALT_STATE; systemChat str ["ALT", GET_ALT_STATE];
+        CYCLE_ALT_STATE; 
+        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["ALT", GET_ALT_STATE];};
         SET_RALT_STATE(false);
         SET_ALTP_STATE(false);
         SET_VS_STATE(false);
         if (GET_ALT_STATE) then {SET_GLOBAL("alt_mode",vtx_uh60_fd_fnc_alt)}else{SET_GLOBAL("alt_mode",nil)};
     };
     case "ALTP": {
-        CYCLE_ALTP_STATE; systemChat str ["ALTP", GET_ALTP_STATE];
+        CYCLE_ALTP_STATE; 
+        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["ALTP", GET_ALTP_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
         SET_VS_STATE(false);
         if (GET_ALTP_STATE) then {SET_GLOBAL("alt_mode",vtx_uh60_fd_fnc_altp)}else{SET_GLOBAL("alt_mode",nil)};
     };
     case "VS": {
-        CYCLE_VS_STATE; systemChat str ["ALTP", GET_VS_STATE];
+        CYCLE_VS_STATE; 
+        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["ALTP", GET_VS_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);

--- a/addons/uh60_fd/functions/fnc_modeSet.sqf
+++ b/addons/uh60_fd/functions/fnc_modeSet.sqf
@@ -23,7 +23,7 @@ switch (_mode) do {
     };
     case "RALT": {
         CYCLE_RALT_STATE; 
-        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["RALT", GET_RALT_STATE];};
+        if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["RALT", GET_RALT_STATE];};
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);
         SET_VS_STATE(false);
@@ -31,7 +31,7 @@ switch (_mode) do {
     };
     case "ALT": {
         CYCLE_ALT_STATE; 
-        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["ALT", GET_ALT_STATE];};
+        if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["ALT", GET_ALT_STATE];};
         SET_RALT_STATE(false);
         SET_ALTP_STATE(false);
         SET_VS_STATE(false);
@@ -39,7 +39,7 @@ switch (_mode) do {
     };
     case "ALTP": {
         CYCLE_ALTP_STATE; 
-        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["ALTP", GET_ALTP_STATE];};
+        if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["ALTP", GET_ALTP_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
         SET_VS_STATE(false);
@@ -47,7 +47,7 @@ switch (_mode) do {
     };
     case "VS": {
         CYCLE_VS_STATE; 
-        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["ALTP", GET_VS_STATE];};
+        if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["ALTP", GET_VS_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);

--- a/addons/uh60_fd/functions/fnc_modeSet.sqf
+++ b/addons/uh60_fd/functions/fnc_modeSet.sqf
@@ -23,7 +23,7 @@ switch (_mode) do {
     };
     case "RALT": {
         CYCLE_RALT_STATE; 
-        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["RALT", GET_RALT_STATE];};
+        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["RALT", GET_RALT_STATE];};
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);
         SET_VS_STATE(false);
@@ -31,7 +31,7 @@ switch (_mode) do {
     };
     case "ALT": {
         CYCLE_ALT_STATE; 
-        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["ALT", GET_ALT_STATE];};
+        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["ALT", GET_ALT_STATE];};
         SET_RALT_STATE(false);
         SET_ALTP_STATE(false);
         SET_VS_STATE(false);
@@ -39,7 +39,7 @@ switch (_mode) do {
     };
     case "ALTP": {
         CYCLE_ALTP_STATE; 
-        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["ALTP", GET_ALTP_STATE];};
+        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["ALTP", GET_ALTP_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
         SET_VS_STATE(false);
@@ -47,7 +47,7 @@ switch (_mode) do {
     };
     case "VS": {
         CYCLE_VS_STATE; 
-        if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str ["ALTP", GET_VS_STATE];};
+        if(vtx_uh60_hui_showDebugMessages) then {systemChat str ["ALTP", GET_VS_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);

--- a/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
+++ b/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
@@ -2,7 +2,7 @@ params ["_displayorcontrol", "_button", "_xPos", "_yPos", "_shift", "_ctrl", "_a
 // driver has the real pilotcam
 if (player == driver (vehicle player)) exitWith {};
 private _standardButtonPressed = (_button == 1) && _ctrl;
-systemChat str _standardButtonPressed;
+if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _standardButtonPressed;};
 if (!_standardButtonPressed) exitWith {
 	!(isNil "vtx_uh60_flir_camera")
 };

--- a/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
+++ b/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
@@ -2,7 +2,7 @@ params ["_displayorcontrol", "_button", "_xPos", "_yPos", "_shift", "_ctrl", "_a
 // driver has the real pilotcam
 if (player == driver (vehicle player)) exitWith {};
 private _standardButtonPressed = (_button == 1) && _ctrl;
-if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _standardButtonPressed;};
+if(vtx_uh60_hui_showDebugMessages) then {systemChat str _standardButtonPressed;};
 if (!_standardButtonPressed) exitWith {
 	!(isNil "vtx_uh60_flir_camera")
 };

--- a/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
+++ b/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
@@ -2,7 +2,7 @@ params ["_displayorcontrol", "_button", "_xPos", "_yPos", "_shift", "_ctrl", "_a
 // driver has the real pilotcam
 if (player == driver (vehicle player)) exitWith {};
 private _standardButtonPressed = (_button == 1) && _ctrl;
-if(vtx_uh60_hui_showDebugMessages) then {systemChat str _standardButtonPressed;};
+if(vtx_uh60_ui_showDebugMessages) then {systemChat str _standardButtonPressed;};
 if (!_standardButtonPressed) exitWith {
 	!(isNil "vtx_uh60_flir_camera")
 };

--- a/addons/uh60_flir/functions/fnc_handleVisionMode.sqf
+++ b/addons/uh60_flir/functions/fnc_handleVisionMode.sqf
@@ -4,7 +4,7 @@ if (inputAction "cameraVisionMode" > 0 && !vtx_uh60_flir_visionChanging) then {
 	_currentVisionMode = if (_currentVisionMode == 3) then [{0}, {_currentVisionMode + 1}];
 	camUseNVG (_currentVisionMode == 1);
 	(_currentVisionMode > 1) setCamUseTI (_currentVisionMode - 2);
-	systemChat str _currentVisionMode;
+	if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _currentVisionMode;};
 	_vehicle setVariable ["vtx_flir_initVisionMode", _currentVisionMode];
 	vtx_uh60_flir_visionChanging = false;
 };

--- a/addons/uh60_flir/functions/fnc_handleVisionMode.sqf
+++ b/addons/uh60_flir/functions/fnc_handleVisionMode.sqf
@@ -4,7 +4,7 @@ if (inputAction "cameraVisionMode" > 0 && !vtx_uh60_flir_visionChanging) then {
 	_currentVisionMode = if (_currentVisionMode == 3) then [{0}, {_currentVisionMode + 1}];
 	camUseNVG (_currentVisionMode == 1);
 	(_currentVisionMode > 1) setCamUseTI (_currentVisionMode - 2);
-	if(vtx_uh60_hui_showDebugMessages) then {systemChat str _currentVisionMode;};
+	if(vtx_uh60_ui_showDebugMessages) then {systemChat str _currentVisionMode;};
 	_vehicle setVariable ["vtx_flir_initVisionMode", _currentVisionMode];
 	vtx_uh60_flir_visionChanging = false;
 };

--- a/addons/uh60_flir/functions/fnc_handleVisionMode.sqf
+++ b/addons/uh60_flir/functions/fnc_handleVisionMode.sqf
@@ -4,7 +4,7 @@ if (inputAction "cameraVisionMode" > 0 && !vtx_uh60_flir_visionChanging) then {
 	_currentVisionMode = if (_currentVisionMode == 3) then [{0}, {_currentVisionMode + 1}];
 	camUseNVG (_currentVisionMode == 1);
 	(_currentVisionMode > 1) setCamUseTI (_currentVisionMode - 2);
-	if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _currentVisionMode;};
+	if(vtx_uh60_hui_showDebugMessages) then {systemChat str _currentVisionMode;};
 	_vehicle setVariable ["vtx_flir_initVisionMode", _currentVisionMode];
 	vtx_uh60_flir_visionChanging = false;
 };

--- a/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
+++ b/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
@@ -10,7 +10,7 @@ for "_i" from 0 to 15 step 1 do {
   private _endPos = _startPos vectorAdd _vectorIntersect;
   private _intersect = terrainIntersectAtASL  [_startPos, _endPos];
   if(!([0,0,0] isEqualTo _intersect)) then {
-	  if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _intersect;};
+	  if(vtx_uh60_hui_showDebugMessages) then {systemChat str _intersect;};
     _intersect breakOut "return";
   };
 };

--- a/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
+++ b/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
@@ -10,7 +10,7 @@ for "_i" from 0 to 15 step 1 do {
   private _endPos = _startPos vectorAdd _vectorIntersect;
   private _intersect = terrainIntersectAtASL  [_startPos, _endPos];
   if(!([0,0,0] isEqualTo _intersect)) then {
-	  systemChat str _intersect;
+	  if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _intersect;};
     _intersect breakOut "return";
   };
 };

--- a/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
+++ b/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
@@ -10,7 +10,7 @@ for "_i" from 0 to 15 step 1 do {
   private _endPos = _startPos vectorAdd _vectorIntersect;
   private _intersect = terrainIntersectAtASL  [_startPos, _endPos];
   if(!([0,0,0] isEqualTo _intersect)) then {
-	  if(vtx_uh60_hui_showDebugMessages) then {systemChat str _intersect;};
+	  if(vtx_uh60_ui_showDebugMessages) then {systemChat str _intersect;};
     _intersect breakOut "return";
   };
 };

--- a/addons/uh60_flir/functions/fnc_stabilizedMovement.sqf
+++ b/addons/uh60_flir/functions/fnc_stabilizedMovement.sqf
@@ -16,7 +16,7 @@ private _newDir = [
 
 private _intersect = [(getPosASL vtx_uh60_flir_camera), _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
 
-systemChat str _intersect;
+if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _intersect;};
 if (!isNil "_intersect") then {
 	_vehicle setPilotCameraTarget _intersect;
 };

--- a/addons/uh60_flir/functions/fnc_stabilizedMovement.sqf
+++ b/addons/uh60_flir/functions/fnc_stabilizedMovement.sqf
@@ -16,7 +16,7 @@ private _newDir = [
 
 private _intersect = [(getPosASL vtx_uh60_flir_camera), _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
 
-if(vtx_uh60_hui_showDebugMessages) then {systemChat str _intersect;};
+if(vtx_uh60_ui_showDebugMessages) then {systemChat str _intersect;};
 if (!isNil "_intersect") then {
 	_vehicle setPilotCameraTarget _intersect;
 };

--- a/addons/uh60_flir/functions/fnc_stabilizedMovement.sqf
+++ b/addons/uh60_flir/functions/fnc_stabilizedMovement.sqf
@@ -16,7 +16,7 @@ private _newDir = [
 
 private _intersect = [(getPosASL vtx_uh60_flir_camera), _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
 
-if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _intersect;};
+if(vtx_uh60_hui_showDebugMessages) then {systemChat str _intersect;};
 if (!isNil "_intersect") then {
 	_vehicle setPilotCameraTarget _intersect;
 };

--- a/addons/uh60_flir/functions/testScripts.sqf
+++ b/addons/uh60_flir/functions/testScripts.sqf
@@ -123,7 +123,7 @@
 	vtx_uh60_flir_fnc_handleStabilization = {
 		params ["_vehicle", "_frameTime"];
 		if (inputAction "vehLockTurretView" > 0 && !vtx_uh60_flir_stabilizing) then {
-			if(vtx_uh60_hui_showDebugMessages) then {systemChat str time;};
+			if(vtx_uh60_ui_showDebugMessages) then {systemChat str time;};
 			_this call vtx_uh60_flir_fnc_toggleStabilization;
 		};
 		if (vtx_uh60_flir_stabilized) then {
@@ -140,12 +140,12 @@
 	vtx_uh60_flir_fnc_toggleStabilization = {
 		params ["_vehicle"];
 		if (!vtx_uh60_flir_stabilized) then {
-			if(vtx_uh60_hui_showDebugMessages) then {systemChat "STAB ON";};
+			if(vtx_uh60_ui_showDebugMessages) then {systemChat "STAB ON";};
 			private _target = screenToWorld [0.5, 0.5];
 			vtx_uh60_flir_stabTarget = _target;
 			vtx_uh60_flir_stabilized = true;
 		} else {
-			if(vtx_uh60_hui_showDebugMessages) then {systemChat "STAB OFF";};
+			if(vtx_uh60_ui_showDebugMessages) then {systemChat "STAB OFF";};
 			vtx_uh60_flir_stabilized = false;
 		};
 		vtx_uh60_flir_camera camCommit 0;

--- a/addons/uh60_flir/functions/testScripts.sqf
+++ b/addons/uh60_flir/functions/testScripts.sqf
@@ -123,7 +123,7 @@
 	vtx_uh60_flir_fnc_handleStabilization = {
 		params ["_vehicle", "_frameTime"];
 		if (inputAction "vehLockTurretView" > 0 && !vtx_uh60_flir_stabilizing) then {
-			if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str time;};
+			if(vtx_uh60_hui_showDebugMessages) then {systemChat str time;};
 			_this call vtx_uh60_flir_fnc_toggleStabilization;
 		};
 		if (vtx_uh60_flir_stabilized) then {
@@ -140,12 +140,12 @@
 	vtx_uh60_flir_fnc_toggleStabilization = {
 		params ["_vehicle"];
 		if (!vtx_uh60_flir_stabilized) then {
-			if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "STAB ON";};
+			if(vtx_uh60_hui_showDebugMessages) then {systemChat "STAB ON";};
 			private _target = screenToWorld [0.5, 0.5];
 			vtx_uh60_flir_stabTarget = _target;
 			vtx_uh60_flir_stabilized = true;
 		} else {
-			if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "STAB OFF";};
+			if(vtx_uh60_hui_showDebugMessages) then {systemChat "STAB OFF";};
 			vtx_uh60_flir_stabilized = false;
 		};
 		vtx_uh60_flir_camera camCommit 0;

--- a/addons/uh60_flir/functions/testScripts.sqf
+++ b/addons/uh60_flir/functions/testScripts.sqf
@@ -123,7 +123,7 @@
 	vtx_uh60_flir_fnc_handleStabilization = {
 		params ["_vehicle", "_frameTime"];
 		if (inputAction "vehLockTurretView" > 0 && !vtx_uh60_flir_stabilizing) then {
-			systemChat str time;
+			if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str time;};
 			_this call vtx_uh60_flir_fnc_toggleStabilization;
 		};
 		if (vtx_uh60_flir_stabilized) then {
@@ -140,12 +140,12 @@
 	vtx_uh60_flir_fnc_toggleStabilization = {
 		params ["_vehicle"];
 		if (!vtx_uh60_flir_stabilized) then {
-			systemChat "STAB ON";
+			if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "STAB ON";};
 			private _target = screenToWorld [0.5, 0.5];
 			vtx_uh60_flir_stabTarget = _target;
 			vtx_uh60_flir_stabilized = true;
 		} else {
-			systemChat "STAB OFF";
+			if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "STAB OFF";};
 			vtx_uh60_flir_stabilized = false;
 		};
 		vtx_uh60_flir_camera camCommit 0;

--- a/addons/uh60_jvmf/functions/fnc_prepareInboxDialog.sqf
+++ b/addons/uh60_jvmf/functions/fnc_prepareInboxDialog.sqf
@@ -4,7 +4,7 @@
 
 params ["_display"];
 private _ctrl = _display displayCtrl 1337;
-systemChat str _ctrl;
+if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _ctrl;};
 private _fixString = {
     params ["_str", "_length"];
     private _str = _str select [0,_length];
@@ -30,7 +30,7 @@ private _fixString = {
     if (count _replies > 0) then {
         _str = _str + ((_replies # 0) # 0);
 	};
-	systemChat _str;
+	if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat _str;};
 	_ctrl lbAdd _str;
 } forEach VTX_JVMF_MESSAGES;
 

--- a/addons/uh60_jvmf/functions/fnc_prepareInboxDialog.sqf
+++ b/addons/uh60_jvmf/functions/fnc_prepareInboxDialog.sqf
@@ -4,7 +4,7 @@
 
 params ["_display"];
 private _ctrl = _display displayCtrl 1337;
-if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _ctrl;};
+if(vtx_uh60_hui_showDebugMessages) then {systemChat str _ctrl;};
 private _fixString = {
     params ["_str", "_length"];
     private _str = _str select [0,_length];
@@ -30,7 +30,7 @@ private _fixString = {
     if (count _replies > 0) then {
         _str = _str + ((_replies # 0) # 0);
 	};
-	if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat _str;};
+	if(vtx_uh60_hui_showDebugMessages) then {systemChat _str;};
 	_ctrl lbAdd _str;
 } forEach VTX_JVMF_MESSAGES;
 

--- a/addons/uh60_jvmf/functions/fnc_prepareInboxDialog.sqf
+++ b/addons/uh60_jvmf/functions/fnc_prepareInboxDialog.sqf
@@ -4,7 +4,7 @@
 
 params ["_display"];
 private _ctrl = _display displayCtrl 1337;
-if(vtx_uh60_hui_showDebugMessages) then {systemChat str _ctrl;};
+if(vtx_uh60_ui_showDebugMessages) then {systemChat str _ctrl;};
 private _fixString = {
     params ["_str", "_length"];
     private _str = _str select [0,_length];
@@ -30,7 +30,7 @@ private _fixString = {
     if (count _replies > 0) then {
         _str = _str + ((_replies # 0) # 0);
 	};
-	if(vtx_uh60_hui_showDebugMessages) then {systemChat _str;};
+	if(vtx_uh60_ui_showDebugMessages) then {systemChat _str;};
 	_ctrl lbAdd _str;
 } forEach VTX_JVMF_MESSAGES;
 

--- a/addons/uh60_mfd/functions/fnc_switchPage.sqf
+++ b/addons/uh60_mfd/functions/fnc_switchPage.sqf
@@ -10,7 +10,7 @@ params ["_vehicle", "_mfdIndex", "_pageIndex", "_propagate"];
 #include "..\config\mfdDefines.hpp"
 
 if (_propagate) exitWith {
-    systemChat "MFD MP Sync";
+    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "MFD MP Sync";};
     [_vehicle, _mfdIndex, _pageIndex, false] remoteExecCall ["vtx_uh60_mfd_fnc_switchPage", crew _vehicle];diag_log "switchPage mfd";
 };
 

--- a/addons/uh60_mfd/functions/fnc_switchPage.sqf
+++ b/addons/uh60_mfd/functions/fnc_switchPage.sqf
@@ -10,7 +10,7 @@ params ["_vehicle", "_mfdIndex", "_pageIndex", "_propagate"];
 #include "..\config\mfdDefines.hpp"
 
 if (_propagate) exitWith {
-    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat "MFD MP Sync";};
+    if(vtx_uh60_hui_showDebugMessages) then {systemChat "MFD MP Sync";};
     [_vehicle, _mfdIndex, _pageIndex, false] remoteExecCall ["vtx_uh60_mfd_fnc_switchPage", crew _vehicle];diag_log "switchPage mfd";
 };
 

--- a/addons/uh60_mfd/functions/fnc_switchPage.sqf
+++ b/addons/uh60_mfd/functions/fnc_switchPage.sqf
@@ -10,7 +10,7 @@ params ["_vehicle", "_mfdIndex", "_pageIndex", "_propagate"];
 #include "..\config\mfdDefines.hpp"
 
 if (_propagate) exitWith {
-    if(vtx_uh60_hui_showDebugMessages) then {systemChat "MFD MP Sync";};
+    if(vtx_uh60_ui_showDebugMessages) then {systemChat "MFD MP Sync";};
     [_vehicle, _mfdIndex, _pageIndex, false] remoteExecCall ["vtx_uh60_mfd_fnc_switchPage", crew _vehicle];diag_log "switchPage mfd";
 };
 

--- a/addons/uh60_missions/VTX_GroundSupport01.Altis/init.sqf
+++ b/addons/uh60_missions/VTX_GroundSupport01.Altis/init.sqf
@@ -63,7 +63,7 @@ if (hasInterface) then {
                         _heli action ["UseMagazine", _heli, _unit, _owner, _id];
                     };
                 } forEach magazinesAllTurrets _heli;
-                    systemChat str _aimTarget;
+                    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _aimTarget;};
                 };
             };
         } forEach [[1], [2]];

--- a/addons/uh60_missions/VTX_GroundSupport01.Altis/init.sqf
+++ b/addons/uh60_missions/VTX_GroundSupport01.Altis/init.sqf
@@ -63,7 +63,7 @@ if (hasInterface) then {
                         _heli action ["UseMagazine", _heli, _unit, _owner, _id];
                     };
                 } forEach magazinesAllTurrets _heli;
-                    if(vtx_uh60m_trackIR_interaction_systemChat) then {systemChat str _aimTarget;};
+                    if(vtx_uh60_hui_showDebugMessages) then {systemChat str _aimTarget;};
                 };
             };
         } forEach [[1], [2]];

--- a/addons/uh60_missions/VTX_GroundSupport01.Altis/init.sqf
+++ b/addons/uh60_missions/VTX_GroundSupport01.Altis/init.sqf
@@ -63,7 +63,7 @@ if (hasInterface) then {
                         _heli action ["UseMagazine", _heli, _unit, _owner, _id];
                     };
                 } forEach magazinesAllTurrets _heli;
-                    if(vtx_uh60_hui_showDebugMessages) then {systemChat str _aimTarget;};
+                    if(vtx_uh60_ui_showDebugMessages) then {systemChat str _aimTarget;};
                 };
             };
         } forEach [[1], [2]];

--- a/addons/uh60_ui/initSettings.sqf
+++ b/addons/uh60_ui/initSettings.sqf
@@ -21,7 +21,7 @@
 ] call CBA_Settings_fnc_init;
 
 [
-    "vtx_uh60_hui_showDebugMessages",
+    "vtx_uh60_ui_showDebugMessages",
     "CHECKBOX",
     [LSTRING(Enable_systemChat), LSTRING(Enable_systemChat)],
     "UH-60M",

--- a/addons/uh60_ui/initSettings.sqf
+++ b/addons/uh60_ui/initSettings.sqf
@@ -21,11 +21,11 @@
 ] call CBA_Settings_fnc_init;
 
 [
-    "vtx_uh60m_trackIR_interaction_systemChat",
+    "vtx_uh60_hui_showDebugMessages",
     "CHECKBOX",
     [LSTRING(Enable_systemChat), LSTRING(Enable_systemChat)],
     "UH-60M",
-    [false],
+    [true],
     nil,
     {}
 ] call CBA_Settings_fnc_init;

--- a/addons/uh60_ui/initSettings.sqf
+++ b/addons/uh60_ui/initSettings.sqf
@@ -19,3 +19,13 @@
     nil,
     {}
 ] call CBA_Settings_fnc_init;
+
+[
+    "vtx_uh60m_trackIR_interaction_systemChat",
+    "CHECKBOX",
+    [LSTRING(Enable_systemChat), LSTRING(Enable_systemChat)],
+    "UH-60M",
+    [false],
+    nil,
+    {}
+] call CBA_Settings_fnc_init;

--- a/addons/uh60_ui/stringtable.xml
+++ b/addons/uh60_ui/stringtable.xml
@@ -13,5 +13,8 @@
         <Key ID="STR_VTX_UH60_UI_DetachedCursorSensitivity">
             <English>Detached Cursor Sensitivity</English>
         </Key>
+        <Key ID="STR_VTX_UH60_UI_Enable_systemChat">
+            <English>(DEBUG) Enable systemChat messages</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Adds CBA option under UH-60M settings group to enable or disable the various systemChat messages throughout the addon. (e.g. "ENGINE STATE CHANGE"). Default is disabled. Left the "NO DISPLAY" systemChat in place in vtx_uh60_jvmf_fnc_openMessage
