### PR TITLE
fix flir mouse slew

### DIFF
--- a/addons/uh60_flir/initKeybinds.sqf
+++ b/addons/uh60_flir/initKeybinds.sqf
@@ -46,10 +46,8 @@
       if (vtx_uh60_flir_isPipHidden || {vtx_uh60_flir_isInScriptedCamera}) exitWith {false};
       vtx_uh60_flir_slewAim = true;
       if (vtx_uh60_flir_setting_AimSlewBlockMouse && {!ace_interact_menu_keyDown}) then {
-        if (!(uiNamespace getVariable ["vtx_uh60_flir_mouseBlocker", false])) then {
           (findDisplay 46) createDisplay "vtx_uh60_flir_mouseBlocker";
           (finddisplay 86005) displayAddEventHandler ["KeyUp", {[_this,'keyup'] call CBA_events_fnc_keyHandler}];
-        };
       };
       false
     },{


### PR DESCRIPTION
having the slew key be bound to ace menu key causes `uiNamespace getVariable ["vtx_uh60_flir_mouseBlocker", false]` to return `true`, which stops a second slew key binding from working after having done slew with the ace key. very edge case.
