### PR TITLE
Don't switch LODs on FFV ADS

### DIFF
--- a/addons/MH60S/config/cargoTurretsGAU21L.hpp
+++ b/addons/MH60S/config/cargoTurretsGAU21L.hpp
@@ -8,6 +8,10 @@ class CargoTurret_01: CargoTurret
     proxyIndex = 12;
     isPersonTurret = 1;        /// this turret is able to fire both when turned in and out
     disableSoundAttenuation = 0;
+    LODTurnedIn = 1200;
+    LODTurnedOut = 1200;
+    LODOpticsIn = 1200;
+    LODOpticsOut = 1200;
     class TurnIn /// limits for gunner turned in
     {
         limitsArrayBottom[] = {[-45,-94.9656],[-45,80.9904],[-31.9033,82.8465],[-31.7935,95]};

--- a/addons/UH60/config/turrets/cargoTurrets.hpp
+++ b/addons/UH60/config/turrets/cargoTurrets.hpp
@@ -7,6 +7,10 @@ class CargoTurret_01: CargoTurret {
     proxyIndex = 12;
     isPersonTurret = 1;        /// this turret is able to fire both when turned in and out
     disableSoundAttenuation = 0;
+    LODTurnedIn = 1200;
+    LODTurnedOut = 1200;
+    LODOpticsIn = 1200;
+    LODOpticsOut = 1200;
     class TurnIn /// limits for gunner turned in
     {
         limitsArrayBottom[] = {[-45,-94.9656],[-45,80.9904],[-31.9033,82.8465],[-31.7935,95]};

--- a/addons/UH60/config/turrets/cargoTurretsDoor.hpp
+++ b/addons/UH60/config/turrets/cargoTurretsDoor.hpp
@@ -7,6 +7,10 @@ class CargoTurret_01: CargoTurret {
     proxyIndex = 12;
     isPersonTurret = 1;        /// this turret is able to fire both when turned in and out
     disableSoundAttenuation = 0;
+    LODTurnedIn = 1200;
+    LODTurnedOut = 1200;
+    LODOpticsIn = 1200;
+    LODOpticsOut = 1200;
     class TurnIn /// limits for gunner turned in
     {
         limitsArrayBottom[] = {[-45,-94.9656],[-45,80.9904],[-31.9033,82.8465],[-31.7935,95]};


### PR DESCRIPTION
**When merged this pull request will:**
- Set the FFV seats to use ViewCargo LOD by default to avoid switching LOD when aiming down sights
- Close #139