### PR TITLE
BugFix - Add APU fuel burn

### DIFF
--- a/addons/uh60_engine/functions/fnc_perSecond.sqf
+++ b/addons/uh60_engine/functions/fnc_perSecond.sqf
@@ -5,6 +5,7 @@
  *
  * params (array)[(object) vehicle]
  */
+
 #include "defines.hpp"
 params ["_vehicle"];
 
@@ -35,6 +36,7 @@ if (_esisCount > -1) then {
 private _temp = ((getPosASL player) # 2) call ace_weather_fnc_calculateTemperatureAtHeight;
 private _tempMultiplier = 1 + (_temp * 0.001);
 private _torqueMultiplier = 1 + ((collectiveRTD _vehicle) * 0.1);
+
 // Update fuel consumption
 { // forEach [GET("ENG1_PWR",0),GET("ENG2_PWR",0)]
     if(_x > 0) then {
@@ -43,14 +45,16 @@ private _torqueMultiplier = 1 + ((collectiveRTD _vehicle) * 0.1);
     };
 } forEach [GET("ENG1_PWR",0),GET("ENG2_PWR",0)];
 
+if(_apuPower) then {
+  _vehicle setFuel ((fuel _vehicle) - ((120/2040) / 60 / 60));
+};
+
 private _fuelConsumed = vtx_uh60_engine_lastFuelLevel - fuel _vehicle;
+
 vtx_uh60_engine_lastFuelLevel = fuel _vehicle;
 if (_fuelConsumed > 0) then {
     private _fuelTimeSecondsTotal = (fuel _vehicle) / _fuelConsumed;
-    private _fuelTimeHours = floor (_fuelTimeSecondsTotal / 60 / 60);
-    private _fuelTimeMinutes = floor (_fuelTimeSecondsTotal / 60 % 60);
-    private _fuelTimeSeconds = round (_fuelTimeSecondsTotal % 60);
-    private _fuelTimeStr = format["%1:%2:%3",_fuelTimeHours, _fuelTimeMinutes, _fuelTimeSeconds];
+    private _fuelTimeStr = [_fuelTimeSecondsTotal] call CBA_fnc_formatElapsedTime;
     vtx_uh60_engine_fuelTime = _fuelTimeStr;
     vtx_uh60_engine_fuelConsumption = _fuelConsumed * 2040 * 60;
     vtx_uh60_engine_fuelRange = round ((_fuelTimeSecondsTotal * (vectorMagnitude (velocity _vehicle))) * 0.000539957);

--- a/addons/uh60_fms/functions/fnc_updateWaypointInfo.sqf
+++ b/addons/uh60_fms/functions/fnc_updateWaypointInfo.sqf
@@ -89,12 +89,12 @@ if (!isNil {VTX_JVMF_MESSAGES # VTX_JVMF_SELECTED_IDX}) then {
     [43, 44] call _clearPos;
 };
 
+private _tofStr = "";
 if (speed _vehicle > 2) then {
-    private _speedMS = vectorMagnitude (velocity _vehicle);
-    private _tofSecondsTotal = (_position distance _vehicle) / _speedMS;
-    private _tofHours = floor (_tofSecondsTotal / 60 / 60);
-    private _tofMinutes = floor (_tofSecondsTotal / 60 % 60);
-    private _tofSeconds = round (_tofSecondsTotal % 60);
-    private _tofStr = format["%1:%2:%3",_tofHours, _tofMinutes, _tofSeconds];
-    _vehicle setUserMFDText [8, _tofStr];
+  private _speedMS = vectorMagnitude (velocity _vehicle);
+  private _tofSecondsTotal = (_position distance _vehicle) / _speedMS;
+  _tofStr = [_tofSecondsTotal] call CBA_fnc_formatElapsedTime;
+} else {
+  _tofStr = "--:--:--";
 };
+_vehicle setUserMFDText [8, _tofStr];


### PR DESCRIPTION
**When merged this pull request will:**
- Adds APU fuel burn at a rate of 120 lbs/hr when running (addresses #259)
- Updated Fuel Time display using `CBA_fnc_formatElapsedTime` to format for padded zeroes, etc.
- Updated TOF/TTG display using `CBA_fnc_formatElapsedTime` to format for padded zeroes, etc.
- TOF/TTG display shows `--:--:--` if velocity is below 2