### PR TITLE
RPT fixes

### DIFF
--- a/addons/MH60M/config.cpp
+++ b/addons/MH60M/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {"vtx_MH60M", "vtx_MH60M_DAP"};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"vtx_UH60"};
+        requiredAddons[] = {"vtx_UH60_weapons"};
         author = "";
         authors[] = {""};
         VERSION_CONFIG;

--- a/addons/MH60M/config/cfgVehicles.hpp
+++ b/addons/MH60M/config/cfgVehicles.hpp
@@ -91,14 +91,14 @@ class CfgVehicles {
                 source="revolving";
                 weapon="vtx_MH60M_M134_minigun";
             };
-            class Muzzle_flash
+            class Muzzle_Flash_M134_L
             {
-                source="ammorandom";
+                source="ammoRandom";
                 weapon="vtx_MH60M_M134_minigun";
             };
-            class Muzzle_flash2
+            class Muzzle_Flash_M134_R
             {
-                source="ammorandom";
+                source="ammoRandom";
                 weapon="vtx_MH60M_M134_minigun";
             };
             class GunnerSeats_Hide: GunnerSeats_Hide {

--- a/addons/MH60S/config.cpp
+++ b/addons/MH60S/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {"vtx_MH60S_Pylons_GAU21L", "vtx_MH60S_GAU21L", "vtx_MH60S_Pylons", "vtx_MH60S"};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"vtx_UH60"};
+        requiredAddons[] = {"vtx_UH60_weapons"};
         author = "";
         authors[] = {""};
         VERSION_CONFIG;

--- a/addons/MH60S/config/cfgVehicles.hpp
+++ b/addons/MH60S/config/cfgVehicles.hpp
@@ -66,6 +66,10 @@ class CfgVehicles {
           ANIM_INIT(MAWS_Tubes_Show,1);
           ANIM_INIT(FLIR_HIDE,0);
           ANIM_INIT(FLIR_BACK,1);
+          class Muzzle_Flash_GAU21_L {
+            source="ammoRandom";
+            weapon="VTX_HMG_M3M";
+          };
         }; // AnimationSources
         hiddenSelectionsTextures[] = {
           "","","","","","","","","","","","","","","","",
@@ -108,6 +112,10 @@ class CfgVehicles {
           ANIM_INIT(MAWS_Tubes_Show,1);
           ANIM_INIT(FLIR_HIDE,0);
           ANIM_INIT(FLIR_BACK,1);
+          class Muzzle_Flash_GAU21_L {
+            source="ammoRandom";
+            weapon="VTX_HMG_M3M";
+          };
         }; // AnimationSources
         hiddenSelectionsTextures[] = {"","","","","","","","","","","","","","","","","z\vtx\addons\MH60S\data\mh60s_main_co.paa","z\vtx\addons\MH60S\data\mh60s_misc_co.paa","z\vtx\addons\MH60S\data\mh60s_tail_co.paa"};
     }; // vtx_MH60S_GAU21L

--- a/addons/MH60S/config/cfgWeapons.hpp
+++ b/addons/MH60S/config/cfgWeapons.hpp
@@ -9,5 +9,23 @@ class cfgWeapons {
         class manual: manual {
             reloadTime = 0.0545;
         };
+        class GunParticles {
+        	class effect1 {
+        		positionName = "GAU21L_End";
+        		directionName = "GAU21L_Beg";
+        		effectName = "MachineGunCloud";
+        	};
+        	class effect2 {
+        		positionName = "GAU21L_eject_pos";
+        		directionName = "GAU21L_eject_dir";
+        		effectName = "MachineGunEject";
+        	};
+        	class effect3 {
+        		positionName = "GAU21L_eject_pos";
+        		directionName = "GAU21L_eject_dir";
+        		effectName = "MachineGunCartridge2";
+        	};
+        };
+
     };
 };

--- a/addons/UH60/config/CfgAnimationSourcesInherit.hpp
+++ b/addons/UH60/config/CfgAnimationSourcesInherit.hpp
@@ -2,8 +2,6 @@ class AnimationSources: AnimationSources {
   class cockpitlight_show;
   class Hoist_Hook_hide;
   class Hoist_hide;
-  class recoil_source;
-  class muzzle_rot;
   class gunner_ffv_l;
   class gunner_ffv_r;
   class Switch_minigun_safe_cover_l;

--- a/addons/UH60/config/cfgAnimationSources.hpp
+++ b/addons/UH60/config/cfgAnimationSources.hpp
@@ -66,6 +66,11 @@ class AnimationSources {
     animPeriod=1;
     initPhase=0;
   };
+  class PositionLights_Show {
+    source="user";
+    animPeriod=1;
+    initPhase=0;
+  };
   class CabinLight_Show {
     source="user";
     animPeriod=1;

--- a/addons/UH60/config/cfgAnimationSources.hpp
+++ b/addons/UH60/config/cfgAnimationSources.hpp
@@ -449,12 +449,12 @@ class AnimationSources {
     source="revolving";
     weapon="vtx_wpn_m134_2nd";
   };
-  class Muzzle_flash {
-    source="ammorandom";
+  class Muzzle_Flash_M134_L {
+    source="ammoRandom";
     weapon="vtx_wpn_m134";
   };
-  class Muzzle_flash2 {
-    source="ammorandom";
+  class Muzzle_Flash_M134_R {
+    source="ammoRandom";
     weapon="vtx_wpn_m134_2nd";
   };
 };

--- a/addons/UH60/config/cfgAnimationSources.hpp
+++ b/addons/UH60/config/cfgAnimationSources.hpp
@@ -8,14 +8,6 @@ class AnimationSources {
     animPeriod=1;
     initPhase=0;
   };
-  class recoil_source {
-    source="reload";
-    weapon="vtx_chaingun";
-  };
-  class muzzle_rot {
-    source="ammorandom";
-    weapon="vtx_chaingun";
-  };
   class gunner_ffv_l {
     source="user";
     animPeriod=0.1;

--- a/addons/UH60/config/cfgVehicles.hpp
+++ b/addons/UH60/config/cfgVehicles.hpp
@@ -15,7 +15,6 @@ class CfgVehicles
     class Helicopter_Base_H;
     class Heli_Transport_01_base_F: Helicopter_Base_H
     {
-    	#include "cfgUVAnimations.hpp"
         class Turrets
         {
             class MainTurret;
@@ -35,6 +34,7 @@ class CfgVehicles
 
     class vtx_H60_base: Heli_Transport_01_base_F
     {
+        #include "cfgUVAnimations.hpp"
         #include "CfgUserActions.hpp"
         #include "edenAttributes.hpp"
         author = "Project Hatchet Studio";

--- a/addons/UH60/config/cfgVehicles.hpp
+++ b/addons/UH60/config/cfgVehicles.hpp
@@ -173,6 +173,8 @@ class CfgVehicles
         icon = "z\vtx\addons\UH60\Data\UI\Map_vtx_UH60_CA.paa";	/// icon in map/editor
         picture = "z\vtx\addons\UH60\Data\UI\vtx_UH60_CA.paa";	/// small picture in command menu
 
+        hideProxyInCombat = 1;
+        viewDriverInExternal = 1;
         driverInAction = UH60_Pilot;
         driverAction = UH60_Pilot;
         driverRightHandAnimName="Cyclic_right";

--- a/addons/UH60/model.cfg
+++ b/addons/UH60/model.cfg
@@ -626,6 +626,19 @@ class CfgModels
 				angle0 = "rad (-40)";
 				angle1 = "rad (40)";
 			};
+			class GAU21L_MuzzleFlash
+			{
+				type = "rotation";
+				source = "Muzzle_Flash_GAU21_L";
+				sourceAddress = "loop";
+				selection = "zasleh_2";
+				axis = "axis_gau21_mf_L";
+				memory = true;
+				minValue = 0;
+				maxValue = 4;
+				angle0 = "rad 0";
+				angle1 = "rad 360";
+			};
 			class GAU21L_ELEV
 			{
 				type = "rotation";
@@ -748,11 +761,11 @@ class CfgModels
 			class MinigunL__Flash
 			{
 				type = "rotation";
-				source = "axis_minigunL_barrels";
+				source = "Muzzle_Flash_M134_L";
 				sourceAddress = "loop";
 				selection = "zasleh";
-				axis = "";
-				centerFirstVertex = true;
+				axis = "axis_minigunL_barrels";
+				memory = 1;
 				minValue = 0;
 				maxValue = 4;
 				angle0 = "rad 0";
@@ -818,11 +831,11 @@ class CfgModels
 			class MinigunR__Flash
 			{
 				type = "rotation";
-				source = "axis_minigunR_barrels";
+				source = "Muzzle_Flash_M134_R";
 				sourceAddress = "loop";
 				selection = "zasleh_1";
-				axis = "";
-				centerFirstVertex = true;
+				axis = "axis_minigunR_barrels";
+				memory = 1;
 				minValue = 0;
 				maxValue = 4;
 				angle0 = "rad 0";

--- a/addons/uh60_config/config/CfgAnimationSources.hpp
+++ b/addons/uh60_config/config/CfgAnimationSources.hpp
@@ -541,12 +541,12 @@ class AnimationSources: AnimationSources {
     source="revolving";
     weapon="vtx_wpn_m134_2nd";
   };
-  class Muzzle_flash {
-    source="ammorandom";
+  class Muzzle_Flash_M134_L {
+    source="ammoRandom";
     weapon="vtx_wpn_m134";
   };
-  class Muzzle_flash2 {
-    source="ammorandom";
+  class Muzzle_Flash_M134_R {
+    source="ammoRandom";
     weapon="vtx_wpn_m134_2nd";
   };
   class Switch_minigun_safe_cover_l {

--- a/addons/uh60_config/config/CfgAnimationSources.hpp
+++ b/addons/uh60_config/config/CfgAnimationSources.hpp
@@ -549,14 +549,6 @@ class AnimationSources: AnimationSources {
     source="ammorandom";
     weapon="vtx_wpn_m134_2nd";
   };
-  class recoil_source {
-    source="reload";
-    weapon="vtx_chaingun";
-  };
-  class muzzle_rot {
-    source="ammorandom";
-    weapon="vtx_chaingun";
-  };
   class Switch_minigun_safe_cover_l {
     source="user";
     animPeriod=0.2;

--- a/addons/uh60_flir/functions/fnc_setup.sqf
+++ b/addons/uh60_flir/functions/fnc_setup.sqf
@@ -58,7 +58,6 @@ vtx_uh60_flir_isVisibleMap = visibleMap;
 call vtx_uh60_flir_fnc_setIsPipHidden;
 
 if (vtx_uh60_flir_playerIsPilot) then {
-  player action ["TurnIn", vehicle player];
   if (productVersion # 2 >= 207) then {
     // https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#VisionModeChanged
     _id = player addEventHandler ["VisionModeChanged", {

--- a/addons/uh60_mfd/config.cpp
+++ b/addons/uh60_mfd/config.cpp
@@ -21,3 +21,4 @@ class CfgPatches
 #include "config\mfdDefines.hpp"
 #include "config\cfgVehicles.hpp"
 #include "config\cfgMagazines.hpp"
+#include "config\cfgWeapons.hpp"

--- a/addons/uh60_mfd/config/cfgMagazines.hpp
+++ b/addons/uh60_mfd/config/cfgMagazines.hpp
@@ -4,5 +4,6 @@ class CfgMagazines {
     ammo = "vtx_pylon_ammo";
     count = 1000;
     displayName = "MFD Fluid";
+    pylonWeapon = "vtx_pylon_mfd";
 	};
 };

--- a/addons/uh60_mfd/config/cfgWeapons.hpp
+++ b/addons/uh60_mfd/config/cfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons {
+	class Laserdesignator_pilotCamera;
+	class vtx_pylon_mfd: Laserdesignator_pilotCamera {
+    magazines[] = {"vtx_1000rnd_dummy"};
+	};
+};

--- a/addons/uh60_mfd/functions/fnc_setPylonValue.sqf
+++ b/addons/uh60_mfd/functions/fnc_setPylonValue.sqf
@@ -11,4 +11,9 @@ params ["_vehicle", "_index", "_value"];
 _vehicle setPylonLoadout [_index, "vtx_1000rnd_dummy", true];
 _vehicle setAmmoOnPylon [_index, _value];
 
+// Weapon vtx_pylon_mfd was added to stop rpt spam from MFD dummy pylons
+if (local _vehicle && {"vtx_pylon_mfd" in weapons _vehicle}) then {
+  _vehicle removeWeapon "vtx_pylon_mfd";
+};
+
 [_vehicle] call vtx_uh60_mfd_fnc_storePylons;

--- a/addons/uh60_weapons/config.cpp
+++ b/addons/uh60_weapons/config.cpp
@@ -6,7 +6,11 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"vtx_UH60"};
+        requiredAddons[] = {
+          "vtx_UH60",
+          "ace_hellfire",
+          "ace_missileguidance"
+        };
         author = "";
         authors[] = {""};
         VERSION_CONFIG;

--- a/addons/uh60_weapons/config/cfgMagazines.hpp
+++ b/addons/uh60_weapons/config/cfgMagazines.hpp
@@ -68,7 +68,7 @@ class cfgMagazines {
     displayNameShort = "19x DAGR";
     mass = 336.5; // 36.3 kg launcher, 15.8 per rocket
     model = QPATHTOF(fza_pod_m261.p3d);
-    pylonWeapon = "ace_missileguidance_dagr";
+    pylonWeapon = "vtx_dagr";
   };
   class VTX_PylonRack_M261_APKWS: PylonRack_12Rnd_PG_missiles {
     ammo = "VTX_APKWS";

--- a/addons/uh60_weapons/config/cfgWeapons.hpp
+++ b/addons/uh60_weapons/config/cfgWeapons.hpp
@@ -43,14 +43,14 @@ class cfgWeapons {
   class missiles_DAR: RocketPods {
     magazines[] += {"VTX_PylonRack_M261_M229"};
   };
-  class missiles_DAGR;
-	class ace_missileguidance_dagr: missiles_DAGR {
-    magazines[] += {"VTX_PylonRack_M261_DAGR"};
+  class ace_missileguidance_dagr;
+	class vtx_dagr: ace_missileguidance_dagr {
+    magazines[] = {"VTX_PylonRack_M261_DAGR"};
     class Burst;
     class Far_AI;
     class Medium_AI;
   };
-	class vtx_apkws: ace_missileguidance_dagr {
+	class vtx_apkws: vtx_dagr {
     displayName = "APKWS";
     displayNameShort = "APKWS";
     magazines[] = {"VTX_PylonRack_M261_APKWS"};

--- a/addons/uh60_weapons/config/cfgWeapons.hpp
+++ b/addons/uh60_weapons/config/cfgWeapons.hpp
@@ -20,8 +20,10 @@ class cfgWeapons {
       displayNameShort = "M230";
       magazines[] = {"VTX_M230_Chaingun_L", "VTX_M230_Chaingun_R"};
       reloadTime = 0.096; // 625 rpm
+      shotFromTurret = 0;
       class player: player {
         displayName = "M230";
+        reloadTime = 0.096; // 625 rpm
       };
       class gunParticles
       {


### PR DESCRIPTION
**When merged this pull request will:**
- Move cfgUVAnimations from Heli_Transport_01_base_F to vtx_H60_base to fix "unknown uv animations"
- Create vtx_dagr to fix wrong 'pylonWeapon' in magazine:'VTX_PylonRack_M261_DAGR' this magazine cannot be used in weapon'ace_missileguidance_dagr'
- Create weapon `vtx_pylon_mfd` for dummy pylons to fix "cannont create weapon for vtx_1000rnd_dummy"
- fix pilot and turrets defaulting to turned out
- show M230 muzzle flash
- show GAU-21 flash and ejecting cases and links https://gfycat.com/impressivewildjenny