### PR TITLE
Feature/Simple startup/shutdown

### DIFF
--- a/addons/UH60/config/cfgVehiclesParts/cfgVxfCockpit.hpp
+++ b/addons/UH60/config/cfgVehiclesParts/cfgVxfCockpit.hpp
@@ -143,7 +143,7 @@ class interaction {
             animation="Lever_fuelsys1";
             animStates[] = {0,0.6,1};
             animLabels[] = {"OFF", "DIR","XFD"};
-            animEnd="[(_this # 0), false, ""fuel""] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""fuelsys"";";
+            animEnd="[(_this # 0), false, ""fuel""] remoteExec [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""fuelsys"";";
         }; // b_fuelsys1
         class b_fuelsys2: b_fuelsys1 {
             position="b_fuelsys2";
@@ -189,7 +189,7 @@ class interaction {
                 animSpeed=0.5;
                 animStates[] = {0,0.85};
                 animLabels[] = {"OFF","FLY"};
-                animEnd="[(_this # 0), (_this # 2 != ""OFF"")] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""powercont"";";
+                animEnd="[(_this # 0), (_this # 2 != ""OFF"")] remoteExec [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""powercont"";";
             }; // b_engpowercont1
             class b_engpowercont2: b_engpowercont1 {
                 position="b_engpowercont2";
@@ -209,7 +209,7 @@ class interaction {
                 animSpeed=0.5;
                 animStates[] = {0,0.23,0.85};
                 animLabels[] = {"OFF", "IDLE","FLY"};
-                animEnd="[(_this # 0), (_this # 2 != ""OFF"")] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""powerocnt"";";
+                animEnd="[(_this # 0), (_this # 2 != ""OFF"")] remoteExec [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""powerocnt"";";
             }; // b_engpowercont1
             class b_engpowercont2: b_engpowercont1 {
                 position="b_engpowercont2";

--- a/addons/uh60_engine/CfgEventHandlers.hpp
+++ b/addons/uh60_engine/CfgEventHandlers.hpp
@@ -9,3 +9,9 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/uh60_engine/XEH_PREP.hpp
+++ b/addons/uh60_engine/XEH_PREP.hpp
@@ -9,3 +9,4 @@ PREP(setup);
 PREP(shutdown);
 PREP(starterState);
 PREP(wheelBrakes);
+PREP(autoStart);

--- a/addons/uh60_engine/XEH_PREP.hpp
+++ b/addons/uh60_engine/XEH_PREP.hpp
@@ -10,3 +10,5 @@ PREP(shutdown);
 PREP(starterState);
 PREP(wheelBrakes);
 PREP(autoStart);
+PREP(autoStop);
+PREP(startStopHandler);

--- a/addons/uh60_engine/XEH_postInit.sqf
+++ b/addons/uh60_engine/XEH_postInit.sqf
@@ -1,0 +1,1 @@
+inGameUISetEventHandler ["Action", "_this call vtx_uh60_engine_fnc_startStopHandler;"];

--- a/addons/uh60_engine/functions/fnc_autoStart.sqf
+++ b/addons/uh60_engine/functions/fnc_autoStart.sqf
@@ -1,0 +1,23 @@
+
+params ["_vehicle"]; 
+[_vehicle, ["startup", "b_gen1"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_gen2"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_batt1"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_batt2"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "fuelPump"], "APU BOOST"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "apucont"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_apugen"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_stbyinst"], "ARM"] call vxf_interaction_fnc_scriptedInteract; 
+
+[_vehicle, ["startup", "b_ignition"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_airsce"], "APU"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_fuelsys1"], "DIR"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_fuelsys2"], "DIR"] call vxf_interaction_fnc_scriptedInteract; 
+sleep 1; 
+[_vehicle, ["startup", "b_starter1"]] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "powerContRTD", "b_engpowercont1"], "FLY"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_starter2"]] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "powerContRTD", "b_engpowercont2"], "FLY"] call vxf_interaction_fnc_scriptedInteract; 
+
+sleep 3; 
+[_vehicle, ["startup", "apucont"], "OFF"] call vxf_interaction_fnc_scriptedInteract; 

--- a/addons/uh60_engine/functions/fnc_autoStart.sqf
+++ b/addons/uh60_engine/functions/fnc_autoStart.sqf
@@ -1,23 +1,27 @@
 
-params ["_vehicle"]; 
-[_vehicle, ["startup", "b_gen1"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_gen2"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_batt1"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_batt2"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "fuelPump"], "APU BOOST"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "apucont"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_apugen"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_stbyinst"], "ARM"] call vxf_interaction_fnc_scriptedInteract; 
+params ["_vehicle"];
+[_vehicle, ["startup", "b_gen1"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_gen2"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_batt1"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_batt2"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "fuelPump"], "APU BOOST"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "apucont"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_apugen"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_stbyinst"], "ARM"] call vxf_interaction_fnc_scriptedInteract;
 
-[_vehicle, ["startup", "b_ignition"], "ON"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_airsce"], "APU"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_fuelsys1"], "DIR"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_fuelsys2"], "DIR"] call vxf_interaction_fnc_scriptedInteract; 
-sleep 1; 
-[_vehicle, ["startup", "b_starter1"]] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "powerContRTD", "b_engpowercont1"], "FLY"] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "b_starter2"]] call vxf_interaction_fnc_scriptedInteract; 
-[_vehicle, ["startup", "powerContRTD", "b_engpowercont2"], "FLY"] call vxf_interaction_fnc_scriptedInteract; 
+[_vehicle, ["startup", "b_ignition"], "ON"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_airsce"], "APU"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_fuelsys1"], "DIR"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_fuelsys2"], "DIR"] call vxf_interaction_fnc_scriptedInteract;
+sleep 1;
+[_vehicle, ["startup", "b_starter1"]] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "powerContRTD", "b_engpowercont1"], "FLY"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_starter2"]] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "powerContRTD", "b_engpowercont2"], "FLY"] call vxf_interaction_fnc_scriptedInteract;
+_vehicle setUserMFDvalue [49,0];
+_vehicle setVariable ["ESIS_COUNTER", -1];
 
-sleep 3; 
-[_vehicle, ["startup", "apucont"], "OFF"] call vxf_interaction_fnc_scriptedInteract; 
+sleep 3;
+[_vehicle, ["startup", "apucont"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "fuelPump"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_airsce"], "OFF"] call vxf_interaction_fnc_scriptedInteract;

--- a/addons/uh60_engine/functions/fnc_autoStart.sqf
+++ b/addons/uh60_engine/functions/fnc_autoStart.sqf
@@ -18,10 +18,11 @@ sleep 1;
 [_vehicle, ["startup", "powerContRTD", "b_engpowercont1"], "FLY"] call vxf_interaction_fnc_scriptedInteract;
 [_vehicle, ["startup", "b_starter2"]] call vxf_interaction_fnc_scriptedInteract;
 [_vehicle, ["startup", "powerContRTD", "b_engpowercont2"], "FLY"] call vxf_interaction_fnc_scriptedInteract;
-_vehicle setUserMFDvalue [49,0];
+_vehicle setUserMFDvalue [49,0];  //Set ESIS value
 _vehicle setVariable ["ESIS_COUNTER", -1];
 
 sleep 3;
 [_vehicle, ["startup", "apucont"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
 [_vehicle, ["startup", "fuelPump"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
 [_vehicle, ["startup", "b_airsce"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, 5, 0] call vtx_uh60_mfd_fnc_setPylonValue; //Turn off starter enunciation

--- a/addons/uh60_engine/functions/fnc_autoStop.sqf
+++ b/addons/uh60_engine/functions/fnc_autoStop.sqf
@@ -1,0 +1,32 @@
+/*
+ * vtx_uh60_engine_fnc_autoStop
+ *
+ * Shuts down aircraft. Called via simple start mode
+ *
+ * params (object) vehicle
+ */
+
+params ["_vehicle"];
+[_vehicle, ["startup", "b_fuelsys1"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_fuelsys2"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+
+sleep 1;
+
+[_vehicle, ["startup", "b_gen1"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_gen2"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_batt1"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_batt2"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "fuelPump"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "apucont"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_apugen"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_stbyinst"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+
+[_vehicle, ["startup", "b_ignition"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_airsce"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_fuelsys1"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "b_fuelsys2"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "powerContRTD", "b_engpowercont1"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+[_vehicle, ["startup", "powerContRTD", "b_engpowercont2"], "OFF"] call vxf_interaction_fnc_scriptedInteract;
+
+
+

--- a/addons/uh60_engine/functions/fnc_batteryState.sqf
+++ b/addons/uh60_engine/functions/fnc_batteryState.sqf
@@ -18,7 +18,7 @@ if (ANIM("GeneratorsOnOff") != _genAnim) then {
     _vehicle animate ["GeneratorsOnOff",_genAnim];
 };
 
-if (_vehicle animationPhase "ESIS_hide" > 0 && typeName _animEndState == "STRING" && {_animName == "Switch_stbyinst"} && {_animEndState == "ARM"}) then {
+if (_vehicle animationPhase "ESIS_hide" > 0 && typeName _animName == "STRING" && typeName _animEndState == "STRING" && {_animName == "Switch_stbyinst"} && {_animEndState == "ARM"}) then {
     _vehicle setVariable ["ESIS_COUNTER", 70, true];
 };
 _vehicle animate ["ESIS_hide",ANIM("Switch_stbyinst")];

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -10,7 +10,16 @@ diag_log format ["%1: engine EH", time];
 
 params ["_vehicle", "_turnedOn", ["_lever","throttle"]];
 
-if (!local _vehicle || vtx_uh60m_simpleStartup) exitWith {};
+if (!local _vehicle) exitWith {};
+
+private _spawnedInAir = (time < 10 && (getPos _vehicle) # 2 > 10);
+private _simpleStart = vtx_uh60m_simpleStartup && _turnedOn;
+private _lastSimpleStart = missionNamespace getVariable ["vtx_uh60_lastSimpleStart", -10];
+if (time < _lastSimpleStart + 5) exitWith {};
+if ((_spawnedInAir || _simpleStart) && time > vtx_uh60_lastSimpleStart + 5) then {
+    vtx_uh60_lastSimpleStart = time;
+    [_vehicle] call vtx_uh60_engine_fnc_autoStart;
+};
 
 if(
     (_vehicle getHitPointDamage "HitEngine1" > 0.3 && _vehicle getHitPointDamage "HitEngine2" > 0.3) ||

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -13,10 +13,11 @@ params ["_vehicle", "_turnedOn", ["_lever","throttle"]];
 if (!local _vehicle) exitWith {};
 
 private _spawnedInAir = (time < 10 && (getPos _vehicle) # 2 > 10);
-private _simpleStart = vtx_uh60m_simpleStartup && _turnedOn;
-private _lastSimpleStart = missionNamespace getVariable ["vtx_uh60_lastSimpleStart", -10];
-if (time < _lastSimpleStart + 5) exitWith {};
-if ((_spawnedInAir || _simpleStart) && time > vtx_uh60_lastSimpleStart + 5) then {
+//private _simpleStart = vtx_uh60m_simpleStartup && _turnedOn;
+//private _lastSimpleStart = missionNamespace getVariable ["vtx_uh60_lastSimpleStart", -10];
+//if (time < _lastSimpleStart + 5) exitWith {};
+//if ((_spawnedInAir || _simpleStart) && time > vtx_uh60_lastSimpleStart + 5) then {
+if (_spawnedInAir) then {
     vtx_uh60_lastSimpleStart = time;
     [_vehicle] call vtx_uh60_engine_fnc_autoStart;
 };

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -17,7 +17,7 @@ private _spawnedInAir = (time < 10 && (getPos _vehicle) # 2 > 10);
 //private _lastSimpleStart = missionNamespace getVariable ["vtx_uh60_lastSimpleStart", -10];
 //if (time < _lastSimpleStart + 5) exitWith {};
 //if ((_spawnedInAir || _simpleStart) && time > vtx_uh60_lastSimpleStart + 5) then {
-if (_spawnedInAir) then {
+if (_spawnedInAir && time > vtx_uh60_lastSimpleStart + 5) then {
     vtx_uh60_lastSimpleStart = time;
     [_vehicle] call vtx_uh60_engine_fnc_autoStart;
 };

--- a/addons/uh60_engine/functions/fnc_perSecond.sqf
+++ b/addons/uh60_engine/functions/fnc_perSecond.sqf
@@ -15,6 +15,8 @@ if (!local _vehicle || vtx_uh60m_simpleStartup) exitWith {
 };
 
 
+private _lastSimpleStart = missionNamespace getVariable ["vtx_uh60_lastSimpleStart", 0];
+if (!local _vehicle || vtx_uh60m_simpleStartup || time < vtx_uh60_lastSimpleStart + 10) exitWith {};
 
 private _eng1Powered = _vehicle getVariable ["ENG1_PWR",0] > 0;
 private _eng2Powered = _vehicle getVariable ["ENG2_PWR",0] > 0;

--- a/addons/uh60_engine/functions/fnc_perSecond.sqf
+++ b/addons/uh60_engine/functions/fnc_perSecond.sqf
@@ -10,13 +10,15 @@
 params ["_vehicle"];
 
 private _esisCount = _vehicle getVariable ["ESIS_COUNTER", 0];
-if (!local _vehicle || vtx_uh60m_simpleStartup) exitWith {
+//if (!local _vehicle || vtx_uh60m_simpleStartup) exitWith {
+if (!local _vehicle ) exitWith {
     _vehicle setUserMFDValue [49, _esisCount];
 };
 
 
 private _lastSimpleStart = missionNamespace getVariable ["vtx_uh60_lastSimpleStart", 0];
-if (!local _vehicle || vtx_uh60m_simpleStartup || time < vtx_uh60_lastSimpleStart + 10) exitWith {};
+//if (!local _vehicle || vtx_uh60m_simpleStartup || time < vtx_uh60_lastSimpleStart + 10) exitWith {};
+if (!local _vehicle || time < vtx_uh60_lastSimpleStart + 10) exitWith {};
 
 private _eng1Powered = _vehicle getVariable ["ENG1_PWR",0] > 0;
 private _eng2Powered = _vehicle getVariable ["ENG2_PWR",0] > 0;

--- a/addons/uh60_engine/functions/fnc_setup.sqf
+++ b/addons/uh60_engine/functions/fnc_setup.sqf
@@ -9,9 +9,10 @@
 params ["_vehicle"];
 if (!vtx_uh60m_enabled_engine) exitWith {false};
 
-vtx_uh60_engine_engineEH = _vehicle addEventHandler ["engine", vtx_uh60_engine_fnc_engineEH];
+vtx_uh60_engine_engineEH = _vehicle addEventHandler ["engine", {_this spawn vtx_uh60_engine_fnc_engineEH}];
 vtx_uh60_engine_lastFuelLevel = fuel _vehicle;
 vtx_uh60_engine_lastAltitude = ((getPosASL _vehicle) # 2);
+vtx_uh60_lastSimpleStart = -10;
 #define SET_GLOBAL_DEFUALT(VAR,DEFAULT) _vehicle setVariable [VAR, _vehicle getVariable [VAR, DEFAULT], true];
 SET_GLOBAL_DEFUALT("ENG1_PWR", 0)
 SET_GLOBAL_DEFUALT("ENG1_PWR", 0)

--- a/addons/uh60_engine/functions/fnc_startStopHandler.sqf
+++ b/addons/uh60_engine/functions/fnc_startStopHandler.sqf
@@ -1,0 +1,28 @@
+/*
+ * vtx_uh60_engine_fnc_startStopHandler
+ *
+ * handles aircraft engine on and off events called by the player via the scroll menu
+ *
+ * params (array)[(object) vehicle]
+ */
+
+params ["_vehicle", "_player", "", "_action"];
+
+if((!local _vehicle) || (!(_vehicle isKindOf "vtx_H60_base"))) exitWith{false};
+
+if(!vtx_uh60m_simpleStartup) exitWith {systemChat "Simple Startup is not enabled";true};
+
+if(_action == "EngineOn") exitWith {
+  [_vehicle] spawn vtx_uh60_engine_fnc_autoStart;
+  _lastSimpleStart = missionNamespace getVariable ['vtx_uh60_lastSimpleStart', -10];
+  vtx_uh60_lastSimpleStart = time;
+  true
+};
+
+if(_action == "EngineOff") exitWith {
+  [_vehicle] spawn vtx_uh60_engine_fnc_autoStop;
+  true
+};
+
+false
+


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a shutdown to compliment #277 
- Allows Simple Startup/Shutdown to coexist with manually starting up/shutting down
- Moves calls to startup/shutdown from engineEH to an `inGameUIEventHandler` to resolve some minor bugs
- Fixes #196 
- Adds `systemChat` noting if Simple Startup isn't enabled

Basically, now this just hits all the same switches a player would have to manually interact with.

If this is approved, #277 can be closed. I broke this out separately because it's a significant departure from the original scheme.


