### PR TITLE
remove mfd dummy weapon on init

### DIFF
--- a/addons/uh60_mfd/CfgEventHandlers.hpp
+++ b/addons/uh60_mfd/CfgEventHandlers.hpp
@@ -15,3 +15,12 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };
+
+class Extended_Init_EventHandlers {
+    class vtx_H60_base {
+        // Weapon vtx_pylon_mfd was added to stop rpt spam from MFD dummy pylons
+        class ADDON {
+            init = QUOTE(call FUNC(initPylons));;
+        };
+    };
+};

--- a/addons/uh60_mfd/XEH_PREP.hpp
+++ b/addons/uh60_mfd/XEH_PREP.hpp
@@ -1,6 +1,7 @@
 PREP(interaction_tac);
 PREP(interaction_slew);
 PREP(isAnyFlirOpened);
+PREP(initPylons);
 PREP(perSecond);
 PREP(perFrame);
 PREP(setup);

--- a/addons/uh60_mfd/functions/fnc_initPylons.sqf
+++ b/addons/uh60_mfd/functions/fnc_initPylons.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+/*
+ * Author: Ampersand
+ * Initialize pylon, weapons, and magazines
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * 0: Success <BOOLEAN>
+ *
+ * Example:
+ * [vxf_vehicle] call vtx_uh60_mfd_fnc_initPylons
+ */
+
+params ["_vehicle"];
+
+if (local _vehicle) then {
+  //_vehicle removeWeapon "vtx_pylon_mfd";
+};


### PR DESCRIPTION
**When merged this pull request will:**
- prevent dummy magazines being assigned to weapon pylons when pylons are configured