### PR TITLE
remove 114L pylon from DAP

### DIFF
--- a/addons/uh60_weapons/config/cfgMagazines.hpp
+++ b/addons/uh60_weapons/config/cfgMagazines.hpp
@@ -1,7 +1,6 @@
 class cfgMagazines {
   class VehicleMagazine;
   class PylonRack_4Rnd_ACE_Hellfire_AGM114K;
-  class PylonRack_4Rnd_ACE_Hellfire_AGM114L;
   class PylonRack_4Rnd_ACE_Hellfire_AGM114N;
   class VTX_4Rnd_ACE_Hellfire_AGM114K: PylonRack_4Rnd_ACE_Hellfire_AGM114K { // 4x Launcher Support Rack
     displayName = "4x AGM-114K [H60]";
@@ -10,14 +9,6 @@ class cfgMagazines {
     //hardpoints[] = {"UNI_SCALPEL", "CUP_NATO_HELO_LARGE", "RHS_HP_HELLFIRE_RACK", "RHS_HP_LONGBOW_RACK"};
     ammo = "VTX_Hellfire_AGM114K";
     pylonWeapon = "vtx_hellfire_launcher";
-  };
-  class VTX_4Rnd_ACE_Hellfire_AGM114L: PylonRack_4Rnd_ACE_Hellfire_AGM114L { // 4x Launcher Support Rack
-    displayName = "4x AGM-114L [H60]";
-    //count = 4;
-    weight = 251.92;
-    //hardpoints[] = {"UNI_SCALPEL", "CUP_NATO_HELO_LARGE", "RHS_HP_HELLFIRE_RACK", "RHS_HP_LONGBOW_RACK"};
-    ammo = "VTX_Hellfire_AGM114L";
-    pylonWeapon = "vtx_hellfire_launcher_L";
   };
   class VTX_4Rnd_ACE_Hellfire_AGM114N: PylonRack_4Rnd_ACE_Hellfire_AGM114N { // 4x Launcher Support Rack
     displayName = "4x AGM-114N [H60]";

--- a/addons/uh60_weapons/config/cfgWeapons.hpp
+++ b/addons/uh60_weapons/config/cfgWeapons.hpp
@@ -5,9 +5,6 @@ class cfgWeapons {
     class vtx_hellfire_launcher: ace_hellfire_launcher {
       magazines[] = {"VTX_4Rnd_ACE_Hellfire_AGM114K"};
     };
-    class vtx_hellfire_launcher_L: ace_hellfire_launcher_L {
-      magazines[] = {"VTX_4Rnd_ACE_Hellfire_AGM114L"};
-    };
     class vtx_hellfire_launcher_N: ace_hellfire_launcher_N {
       magazines[] = {"VTX_4Rnd_ACE_Hellfire_AGM114N"};
     };


### PR DESCRIPTION
fix #334 

forgot to remove the actual pylon itself in 0.5.2, missiles no longer exist