### PR TITLE
Fix no ammo on pylon script error

### DIFF
--- a/addons/uh60_cas/functions/fnc_updateOverlayList.sqf
+++ b/addons/uh60_cas/functions/fnc_updateOverlayList.sqf
@@ -15,7 +15,7 @@ for "_i" from 14 to 19 do {
 	if (_forEachIndex > 5) exitWith {};
 	_vehicle setUserMFDText [14 + _forEachIndex, _x];
 } forEach vtx_uh60_cas_cautionsLog;
-if (_canOpen || _vehicle ammoOnPylon 3 > 0) then {
+if (_canOpen || (_vehicle ammoOnPylon 3) isNotEqualTo 0) then {
 	[_vehicle, 3, 1 + vtx_uh60_cas_cautionsUnacked] call vtx_uh60_mfd_fnc_setPylonValue;
 };
 [_vehicle, 46, (missionNamespace getVariable ["vtx_uh60_cas_firstAdvisory", 0])] call vtx_uh60_mfd_fnc_setPylonValue;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix no ammo on pylon script error

`ammoOnPylon` command can return a boolean on failure, `isNotEqualTo` can compare different types without error.