### PR TITLE
Wrap all active debug messages under a setting

### DIFF
--- a/addons/UH60/config/cfgVehiclesParts/cfgVxfCockpit.hpp
+++ b/addons/UH60/config/cfgVehiclesParts/cfgVxfCockpit.hpp
@@ -161,7 +161,7 @@ class interaction {
             animation="Lever_fuelsys1";
             animStates[] = {0,0.6,1};
             animLabels[] = {"OFF", "DIR","XFD"};
-            animEnd="[(_this # 0), false, ""fuel""] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""fuelsys"";";
+            animEnd="[(_this # 0), false, ""fuel""] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)]; if (vtx_uh60_ui_showDebugMessages) then {diag_log ""fuelsys"";};";
         }; // b_fuelsys1
         class b_fuelsys2: b_fuelsys1 {
             position="b_fuelsys2";
@@ -208,7 +208,7 @@ class interaction {
                 animSpeed=0.5;
                 animStates[] = {0,0.23,0.85}; // no idle for the moment for SFM
                 animLabels[] = {"OFF","IDLE","FLY"};
-                animEnd="[(_this # 0), (_this # 2 != ""OFF""), ""throttle"", (_this # 2), (_this # 1)] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""powercont"";";
+                animEnd="[(_this # 0), (_this # 2 != ""OFF""), ""throttle"", (_this # 2), (_this # 1)] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)]; if (vtx_uh60_ui_showDebugMessages) then {diag_log ""powercont"";};";
             }; // b_engpowercont1
             class b_engpowercont2: b_engpowercont1 {
                 position="b_engpowercont2";
@@ -228,7 +228,7 @@ class interaction {
                 animSpeed=0.5;
                 animStates[] = {0,0.23,0.85};
                 animLabels[] = {"OFF", "IDLE","FLY"};
-                animEnd="[(_this # 0), (_this # 2 != ""OFF""), ""throttle"", (_this # 2), (_this # 1)] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)];diag_log ""powercont"";";
+                animEnd="[(_this # 0), (_this # 2 != ""OFF""), ""throttle"", (_this # 2), (_this # 1)] remoteExecCall [""vtx_uh60_engine_fnc_engineEH"", crew (_this # 0)]; if (vtx_uh60_ui_showDebugMessages) then {diag_log ""powercont"";};";
             }; // b_engpowercont1
             class b_engpowercont2: b_engpowercont1 {
                 position="b_engpowercont2";

--- a/addons/uh60_engine/functions/fnc_acftSoundController.sqf
+++ b/addons/uh60_engine/functions/fnc_acftSoundController.sqf
@@ -9,7 +9,7 @@ private _apuState           = _vehicle getVariable "vtx_uh60_acft_apuState";
 switch (_apuState) do {
     case "OFF": {
         if (_apuPwrSwitchState == "ON" && _apuFuelSwitchState == "ON") then {
-            systemChat format ["Sound should play!"];
+            if (vtx_uh60_ui_showDebugMessages) then {systemChat format ["Sound should play!"];};
             vtx_uh60_apuSound_dummy = "#dynamicsound" createVehicleLocal ASLToAGL getPosWorld vehicle player;
             vtx_uh60_apuSound_dummy attachTo [_vehicle, [0,-1,1]];
             vtx_uh60_apuSound_dummy say3d    ["VTX_UH60_Start_APU", 50, 1];
@@ -34,7 +34,7 @@ private _eng1StarterState = _vehicle getVariable "vtx_uh60_acft_eng1StarterState
 if (_eng1StarterState == "ON") then {
     vtx_uh60_start1_dummy = "#dynamicsound" createVehicleLocal ASLToAGL getPosWorld vehicle player;
     vtx_uh60_start1_dummy attachTo [_vehicle, [-1,-1,1]];
-    vtx_uh60_start1_dummy say3d    ["VTX_UH60_Start_APU", 50, 2];    
+    vtx_uh60_start1_dummy say3d    ["VTX_UH60_Start_APU", 50, 2];
 } else {
     if (!isNil "vtx_uh60_apuSound_dummy") then {deleteVehicle vtx_uh60_apuSound_dummy};
 };
@@ -44,7 +44,7 @@ private _eng2StarterState = _vehicle getVariable "vtx_uh60_acft_eng2StarterState
 if (_eng2StarterState == "ON") then {
     vtx_uh60_start2_dummy = "#dynamicsound" createVehicleLocal ASLToAGL getPosWorld vehicle player;
     vtx_uh60_start2_dummy attachTo [_vehicle, [-1,-1,1]];
-    vtx_uh60_start2_dummy say3d    ["VTX_UH60_Start_APU", 50, 2];    
+    vtx_uh60_start2_dummy say3d    ["VTX_UH60_Start_APU", 50, 2];
 } else {
     if (!isNil "vtx_uh60_apuSound_dummy") then {deleteVehicle vtx_uh60_apuSound_dummy};
 };

--- a/addons/uh60_engine/functions/fnc_wheelBrakes.sqf
+++ b/addons/uh60_engine/functions/fnc_wheelBrakes.sqf
@@ -9,7 +9,8 @@ private _isEnabled = false;
 if (count _this > 2) then {
     params ["_vehicle", "_animation", "_animationTargetLabel", "_animationTarget"];
     private _state = if (_this # 2 == "OFF") then [{0},{1}];
-    [_vehicle, [_state, 3]] remoteExec ["setBrakesRTD", _vehicle]; diag_log "brakes exec";
+    [_vehicle, [_state, 3]] remoteExec ["setBrakesRTD", _vehicle];
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "brakes exec";};
     _isEnabled = (_this # 2 == "ON");
 } else {
     params ["_vehicle"];

--- a/addons/uh60_fd/functions/fnc_PSYNC.sqf
+++ b/addons/uh60_fd/functions/fnc_PSYNC.sqf
@@ -33,4 +33,5 @@ switch (_mode) do {
     };
 };
 
-[_vehicle] remoteExecCall ["vtx_uh60_fd_fnc_updatePanel", crew _vehicle];diag_log "psync";
+[_vehicle] remoteExecCall ["vtx_uh60_fd_fnc_updatePanel", crew _vehicle];
+if (vtx_uh60_ui_showDebugMessages) then {diag_log "psync";};

--- a/addons/uh60_fd/functions/fnc_altp.sqf
+++ b/addons/uh60_fd/functions/fnc_altp.sqf
@@ -16,5 +16,6 @@ private _alt = (getPosASL _vehicle) # 2;
 if (abs(_alt - _altp) < 10) then {
     SET_ALT(GET_ALTP);
     [_vehicle, "ALT"] call vtx_uh60_fd_fnc_modeSet;
-    [_vehicle] remoteExecCall ["vtx_uh60_fd_fnc_updatePanel", crew _vehicle];diag_log "altp";
+    [_vehicle] remoteExecCall ["vtx_uh60_fd_fnc_updatePanel", crew _vehicle];
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "altp";};
 };

--- a/addons/uh60_fd/functions/fnc_modeSet.sqf
+++ b/addons/uh60_fd/functions/fnc_modeSet.sqf
@@ -25,7 +25,7 @@ switch (_mode) do {
         SET_GLOBAL("pitch_mode",nil);
     };
     case "RALT": {
-        CYCLE_RALT_STATE; 
+        CYCLE_RALT_STATE;
         if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["RALT", GET_RALT_STATE];};
         SET_ALT_STATE(false);
         SET_ALTP_STATE(false);
@@ -33,7 +33,7 @@ switch (_mode) do {
         if (GET_RALT_STATE) then {SET_GLOBAL("alt_mode",vtx_uh60_fd_fnc_ralt)}else{SET_GLOBAL("alt_mode",nil)};
     };
     case "ALT": {
-        CYCLE_ALT_STATE; 
+        CYCLE_ALT_STATE;
         if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["ALT", GET_ALT_STATE];};
         SET_RALT_STATE(false);
         SET_ALTP_STATE(false);
@@ -41,7 +41,7 @@ switch (_mode) do {
         if (GET_ALT_STATE) then {SET_GLOBAL("alt_mode",vtx_uh60_fd_fnc_alt)}else{SET_GLOBAL("alt_mode",nil)};
     };
     case "ALTP": {
-        CYCLE_ALTP_STATE; 
+        CYCLE_ALTP_STATE;
         if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["ALTP", GET_ALTP_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
@@ -49,7 +49,7 @@ switch (_mode) do {
         if (GET_ALTP_STATE) then {SET_GLOBAL("alt_mode",vtx_uh60_fd_fnc_altp)}else{SET_GLOBAL("alt_mode",nil)};
     };
     case "VS": {
-        CYCLE_VS_STATE; 
+        CYCLE_VS_STATE;
         if(vtx_uh60_ui_showDebugMessages) then {systemChat str ["ALTP", GET_VS_STATE];};
         SET_RALT_STATE(false);
         SET_ALT_STATE(false);
@@ -96,4 +96,5 @@ switch (_mode) do {
     };
 };
 
-[_vehicle] remoteExecCall ["vtx_uh60_fd_fnc_updatePanel", crew _vehicle];diag_log "modeSet";
+[_vehicle] remoteExecCall ["vtx_uh60_fd_fnc_updatePanel", crew _vehicle];
+if (vtx_uh60_ui_showDebugMessages) then {diag_log "modeSet";};

--- a/addons/uh60_flir/functions/fnc_toggleLaser.sqf
+++ b/addons/uh60_flir/functions/fnc_toggleLaser.sqf
@@ -15,7 +15,7 @@
 params ["_vehicle"];
 private _pilot = driver _vehicle;
 if (isNull _pilot) exitWith {
-  systemChat "Cannot toggle laser if pilot seat is empty.";
+  if (vtx_uh60_ui_showDebugMessages) then {systemChat "Cannot toggle laser if pilot seat is empty.";};
   false
 };
 

--- a/addons/uh60_hoist/functions/fnc_attachHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_attachHook.sqf
@@ -62,26 +62,26 @@ _unit setVariable [QGVAR(pfhID), [{
   // Exit checks
   {
     if (isNull _x) then {
-      diag_log _args;
+      if (vtx_uh60_ui_showDebugMessages) then {diag_log _args;};
       _unit setVariable [QGVAR(pfhID), -1, true];
     };
   } forEach _args;
 
   // Unit in other vehicle
   if (_vehicleUnit != _unit && {_vehicleUnit != _hook}) then {
-    diag_log "in other vic";
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "in other vic";};
     _unit setVariable [QGVAR(pfhID), -1, true];
   };
 
   // Unit exited/detached hook
   if (!_isUnitInHook && {!_hookAttachedToUnit}) then {
-    diag_log "manual";
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "manual";};
     _unit setVariable [QGVAR(pfhID), -1, true];
   };
 
   // Exit
   if (_pfhID != (_unit getVariable [QGVAR(pfhID), -1])) exitWith {
-    diag_log "vtx_uh60_hoist_fnc_attachHook";
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "vtx_uh60_hoist_fnc_attachHook";};
     [_pfhID] call CBA_fnc_removePerFrameHandler;
     if (_isUnitInHook) then {
       moveOut _unit;

--- a/addons/uh60_jvmf/functions/fnc_attemptSendMessage.sqf
+++ b/addons/uh60_jvmf/functions/fnc_attemptSendMessage.sqf
@@ -41,7 +41,8 @@ private _success = switch (_type) do {
 if (_success) then {
     private _timestamp = [daytime, "HH:MM"] call BIS_fnc_timeToString;
     _this set [6, [[_timestamp, _sender, "SENT", player]]];
-    _this remoteExecCall ["vtx_uh60_jvmf_fnc_receiveMessage", 0];diag_log "attemptSend";
+    _this remoteExecCall ["vtx_uh60_jvmf_fnc_receiveMessage", 0];
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "attemptSend";};
 };
 
 _success

--- a/addons/uh60_jvmf/functions/fnc_openMessage.sqf
+++ b/addons/uh60_jvmf/functions/fnc_openMessage.sqf
@@ -15,7 +15,7 @@ switch (_type) do {
 };
 // sleep 0.1;
 private _newDisplay = uiNamespace getVariable "vtx_uh60_jvmf_display";
-if (isNil "_newDisplay") exitWith {systemChat "NO DISPLAY";};
+if (isNil "_newDisplay") exitWith {if(vtx_uh60_ui_showDebugMessages) then {systemChat "NO DISPLAY";}};
 (_newDisplay displayCtrl 1400) ctrlSetText _recipient;
 for "_i" from 0 to 9 do {
     (_newDisplay displayCtrl (1402 + _i)) ctrlSetText (_text # _i);

--- a/addons/uh60_jvmf/functions/fnc_receiveMessage.sqf
+++ b/addons/uh60_jvmf/functions/fnc_receiveMessage.sqf
@@ -7,11 +7,11 @@
 VTX_JVMF_MESSAGES pushBack _this;
 
 params ["_ID", "_sender", "_recipient", "_type", "_text", "_data", "_replies"];
-systemChat "RECEIVED JVMF";
+if(vtx_uh60_ui_showDebugMessages) then {systemChat "RECEIVED JVMF";};
 
 // systemChat str [_replySender, player];
 if ((_replies # 0 # 3) != player) then {
-	systemChat "REGISTERING ADVISORY";
+	if(vtx_uh60_ui_showDebugMessages) then {systemChat "REGISTERING ADVISORY";};
 	[vehicle player,"NEW JVMF MSG",{},false,false] call vtx_uh60_cas_fnc_registerCautionAdvisory;
 };
 [vehicle player] call vtx_uh60_jvmf_fnc_drawJVMF;

--- a/addons/uh60_jvmf/functions/fnc_receiveReply.sqf
+++ b/addons/uh60_jvmf/functions/fnc_receiveReply.sqf
@@ -15,7 +15,7 @@ VTX_JVMF_MESSAGES set [_messageIndex, _message];
 
 
 if (_senderObject != player) then {
-	systemChat "REGISTERING ADVISORY";
+	if(vtx_uh60_ui_showDebugMessages) then {systemChat "REGISTERING ADVISORY";};
 	[vehicle player,"NEW JVMF REPLY",{},false,false] call vtx_uh60_cas_fnc_registerCautionAdvisory;
 };
 

--- a/addons/uh60_jvmf/functions/fnc_reply.sqf
+++ b/addons/uh60_jvmf/functions/fnc_reply.sqf
@@ -10,4 +10,5 @@ private _timestamp = [daytime, "HH:MM"] call BIS_fnc_timeToString;
 private _message = VTX_JVMF_MESSAGES # VTX_JVMF_SELECTED_IDX;
 _message params ["_ID", "_sender", "_recipient", "_type", "_text", "_data", "_replies"];
 
-[_replySender, _ID, _reply, _timestamp, player] remoteExecCall ["vtx_uh60_jvmf_fnc_receiveReply"];diag_log "reply";
+[_replySender, _ID, _reply, _timestamp, player] remoteExecCall ["vtx_uh60_jvmf_fnc_receiveReply"];
+if (vtx_uh60_ui_showDebugMessages) then {diag_log "reply";};

--- a/addons/uh60_mfd/functions/fnc_switchPage.sqf
+++ b/addons/uh60_mfd/functions/fnc_switchPage.sqf
@@ -15,7 +15,8 @@ if ((_mfdIndex == MFD_1_PAGE_INDEX || _mfdIndex == MFD_1_PAGE_INDEX) && _pageInd
 
 if (_propagate) exitWith {
     if(vtx_uh60_ui_showDebugMessages) then {systemChat "MFD MP Sync";};
-    [_vehicle, _mfdIndex, _pageIndex, false] remoteExecCall ["vtx_uh60_mfd_fnc_switchPage", crew _vehicle];diag_log "switchPage mfd";
+    [_vehicle, _mfdIndex, _pageIndex, false] remoteExecCall ["vtx_uh60_mfd_fnc_switchPage", crew _vehicle];
+    if (vtx_uh60_ui_showDebugMessages) then {diag_log "switchPage mfd";};
 };
 
 _vehicle setUserMFDValue [_mfdIndex, _pageIndex];

--- a/addons/uh60_misc/functions/fnc_loadingScreen.sqf
+++ b/addons/uh60_misc/functions/fnc_loadingScreen.sqf
@@ -9,14 +9,14 @@ vtx_uh60_misc_fnc_loadingScreen = {
 		_ctrl ctrlCommit 0;
 	};
 	params ["_display", "_action"];
-	systemchat str _this;
+	if(vtx_uh60_ui_showDebugMessages) then {systemchat str _this;};
 	(_display displayCtrl 1001) ctrlSetText "Project Hatchet H-60 Pack";
 	(_display displayCtrl 1001) ctrlShow false;
 	(_display displayCtrl 1001) ctrlCommit 0;
 	[1001, "Project Hatchet H-60 Pack"] call _setText;
 	[1002, "By the Project Hatchet Team"] call _setText;
 	[1102, "Map description goes here"] call _setText;
-	
+
 	// (_display displayCtrl 2300)  ctrlShow true; // mission
 	// (_display displayCtrl 2300) ctrlCommit 0; // mission
 
@@ -25,15 +25,15 @@ vtx_uh60_misc_fnc_loadingScreen = {
 	(_display displayCtrl 999) ctrlSetPosition [safezonex, safezoney, safezonew, safezoneh];
 	(_display displayCtrl 999) ctrlCommit 0; // idk
 
-	
+
 	(_display displayCtrl 2310)  ctrlShow false; // arma 3 image in background
 	(_display displayCtrl 2310) ctrlCommit 0; // arma 3 image in background
-	
+
 	(_display displayCtrl 2301) ctrlShow true; // disclaimer
 	(_display displayCtrl 2301) ctrlCommit 0; // disclaimer
 	[1009, "Project Hatchet Loader", 2301] call _setText;
 	[1101, "Loading the Project Hatchet H-60 Pack<br/>Due to technical limitations of the arma engine, we need to pre-load the Hathet H-60 Pack to avoid loading freezes during gameplay.", 2301] call _setText;
-	
+
 	(_display displayCtrl 104) progressSetPosition 0.5; // loading bar
 	(_display displayCtrl 104) ctrlCommit 0;
 };

--- a/addons/uh60_sfmplus/functions/forces/fn_antiLift.sqf
+++ b/addons/uh60_sfmplus/functions/forces/fn_antiLift.sqf
@@ -29,11 +29,11 @@ if (_rtrRPM > 0 && _rtrRPM < 0.7) then {
     private _realRPM = _heli animationPhase "rotortilt";
     // systemChat str [_realRPM / 10, _rtrRPM];
     if ((_realRPM / 10) > _rtrRPM) then {
-        systemchat "BREAKING";
+        if (vtx_uh60_ui_showDebugMessages) then {systemchat "BREAKING";};
         // _heli setHitpointDamage ["HitHRotor", 0.9];
         _heli engineOn false;
     } else {
-        systemchat "FIXING";
+        if (vtx_uh60_ui_showDebugMessages) then {systemchat "FIXING";};
         // _heli setHitpointDamage ["HitHRotor", 0];
         _heli engineOn true;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Hide `systemChat` debug messages if debug is not enabled, providing a more seamless experience.

All components should depend on `uh60_ui`, but as long as the whole pack is used, it shouldn't be a problem - and this is not the first use of the variable without the dependency.

Additionally, the best way to solve all of this would be to macroize the `diag_log` and `systemChat`, with a macro using either this setting or CBA's `DEBUG_MODE_X` (that obviously wouldn't support runtime enabling/disabling though).