### PR TITLE
Bugfix: Vision mode resetting on PiP cam

### DIFF
--- a/addons/uh60_flir/functions/fnc_initVars.sqf
+++ b/addons/uh60_flir/functions/fnc_initVars.sqf
@@ -48,4 +48,4 @@ vtx_uh60_flir_otherPilotIsPlayer = false;
 vtx_uh60_flir_isCopilotInGunnerView = false;
 vtx_uh60_flir_lastSyncTimePilotCamera = 0;
 vtx_uh60_flir_lastSyncTimeAnimation = 0;
-vtx_uh60_flir_pipEffect = [];
+vtx_uh60_flir_pipEffect = [0];

--- a/addons/uh60_mfd/functions/fnc_switchPage.sqf
+++ b/addons/uh60_mfd/functions/fnc_switchPage.sqf
@@ -39,6 +39,7 @@ switch (true) do {
           _slingCam = true;
         } else {
           [_vehicle] call vtx_uh60_flir_fnc_pipStart;
+          "vtx_uh60_flir_feed" setPiPEffect vtx_uh60_flir_pipEffect;
         };
       };
     };


### PR DESCRIPTION
fix #443 

Fix PiP vision mode resetting with mfd interaction
Fix cycling vision mode requiring a double press on first init 