### PR TITLE
Fix multiplayer tac map texture sync

### DIFF
--- a/addons/uh60_mfd/config/interaction.hpp
+++ b/addons/uh60_mfd/config/interaction.hpp
@@ -89,17 +89,17 @@ class tac {
     
     class SUBPAGE_MAPCONF {
         condition = USERVAL(MFD_PAGE_INDEX,TAC_MODE_MAPCONF);
-        MFD_BTN(MFD_8,QUOTE(Topo)) 
-            buttonUp="[vehicle player, 'topo'] call vtx_uh60_mfd_fnc_tac_setMapTexture";
+        MFD_BTN(MFD_8,QUOTE(Topo))
+            buttonUp = QUOTE([ARR_3((_this select 0),'topo',MFD_PAGE_INDEX)] call vtx_uh60_mfd_fnc_tac_setMapTexture);
         };
-        MFD_BTN(MFD_9,QUOTE(Sat)) 
-            buttonUp="[vehicle player, 'sat'] call vtx_uh60_mfd_fnc_tac_setMapTexture";
+        MFD_BTN(MFD_9,QUOTE(Sat))
+            buttonUp = QUOTE([ARR_3((_this select 0),'sat',MFD_PAGE_INDEX)] call vtx_uh60_mfd_fnc_tac_setMapTexture);
         };
-        MFD_BTN(MFD_10,QUOTE(Custom)) 
-            buttonUp="[vehicle player, 'cust'] call vtx_uh60_mfd_fnc_tac_setMapTexture";
+        MFD_BTN(MFD_10,QUOTE(Custom))
+            buttonUp = QUOTE([ARR_3((_this select 0),'cust',MFD_PAGE_INDEX)] call vtx_uh60_mfd_fnc_tac_setMapTexture);
         };
-        MFD_BTN(MFD_11,QUOTE(Off)) 
-            buttonUp="[vehicle player, 'off'] call vtx_uh60_mfd_fnc_tac_setMapTexture";
+        MFD_BTN(MFD_11,QUOTE(Off))
+            buttonUp = QUOTE([ARR_3((_this select 0),'off',MFD_PAGE_INDEX)] call vtx_uh60_mfd_fnc_tac_setMapTexture);
         };
         MFD_BTN(MFD_12,QUOTE(Return)) 
             buttonUp= QUOTE([ARR_4((_this select 0), MFD_PAGE_INDEX, MFD_PAGE_TAC, true)] call vtx_uh60_mfd_fnc_switchPage);

--- a/addons/uh60_mfd/functions/fnc_setup.sqf
+++ b/addons/uh60_mfd/functions/fnc_setup.sqf
@@ -32,7 +32,10 @@ vtx_uh60_mfd_slewY = 0;
 vtx_uh60_mfd_allowText = true;
 vtx_uh60_tac_hookedObject = nil;
 
-vtx_uh60_mfd_mapTextureMode = "topo";
+_vehicle setVariable ["vtx_uh60_mfd_23_mapTextureMode", "topo", true];
+_vehicle setVariable ["vtx_uh60_mfd_24_mapTextureMode", "topo", true];
+_vehicle setVariable ["vtx_uh60_mfd_25_mapTextureMode", "topo", true];
+_vehicle setVariable ["vtx_uh60_mfd_26_mapTextureMode", "topo", true];
 
 vtx_uh60_mfd_mfsc_focussedMFD = 25;
 if (player != driver _vehicle) then {

--- a/addons/uh60_mfd/functions/fnc_switchPage.sqf
+++ b/addons/uh60_mfd/functions/fnc_switchPage.sqf
@@ -9,7 +9,7 @@
 params ["_vehicle", "_mfdIndex", "_pageIndex", "_propagate"];
 #include "..\config\mfdDefines.hpp"
 
-if ((_mfdIndex == MFD_1_PAGE_INDEX || _mfdIndex == MFD_1_PAGE_INDEX) && _pageIndex == MFD_PAGE_CCFS_MENU) exitWith {
+if ((_mfdIndex == MFD_1_PAGE_INDEX || _mfdIndex == MFD_4_PAGE_INDEX) && _pageIndex == MFD_PAGE_CCFS_MENU) exitWith {
   ["Warning\nThe CCFS can only be opened on MFD 2 and 3"] call vtx_uh60_misc_fnc_hint;
 };
 
@@ -24,7 +24,7 @@ _vehicle setUserMFDValue [_mfdIndex, _pageIndex];
 private _slingCam = false;
 switch (true) do {
     case (_pageIndex > MFD_PAGE_TAC - 0.01 && _pageIndex < MFD_PAGE_TAC + 0.99): {
-        private _texture = [_vehicle] call vtx_uh60_mfd_fnc_tac_getMapTexture;
+        private _texture = [_vehicle, _mfdIndex] call vtx_uh60_mfd_fnc_tac_getMapTexture;
         _vehicle setObjectTextureGlobal [MAP_SELECTION(_mfdIndex), _texture];
         _vehicle setObjectMaterialGlobal [MAP_SELECTION(_mfdIndex), "z\vtx\addons\uh60_mfd\data\Emmisive\Emmisive_2.rvmat"];
         _vehicle setObjectTextureGlobal [MFD_OVERLAY(_mfdIndex), "z\vtx\addons\uh60_mfd\data\Overlay_ca.paa"];

--- a/addons/uh60_mfd/functions/fnc_tac_getMapTexture.sqf
+++ b/addons/uh60_mfd/functions/fnc_tac_getMapTexture.sqf
@@ -1,10 +1,12 @@
 /*
  * vtx_uh60_mfd_fnc_tac_getMapTexture
  */
-params ["_vehicle"];
+params ["_vehicle","_mfdIndex"];
+
+private _mode = _vehicle getVariable format["vtx_uh60_mfd_%1_mapTextureMode", _mfdIndex];
 
 private _fallbackMap = getText (configFile >> "CfgWorlds" >> worldName >> "pictureMap");
-private _texture = switch (vtx_uh60_mfd_mapTextureMode) do {
+private _texture = switch (_mode) do {
 	case "topo": {
         private _mapName = format ["z\vtx\addons\uh60_mfd\data\maps\%1_co.paa", worldName];
 		if (fileExists _mapName) then {_mapName} else {""};

--- a/addons/uh60_mfd/functions/fnc_tac_setMapTexture.sqf
+++ b/addons/uh60_mfd/functions/fnc_tac_setMapTexture.sqf
@@ -1,13 +1,12 @@
 /*
  * vtx_uh60_mfd_fnc_tac_setMapTexture
  */
-params ["_vehicle","_textureMode"];
-vtx_uh60_mfd_mapTextureMode = _textureMode;
-{
-	private _pageIndex = (getUserMFDValue _vehicle) # _x;
-	if (_pageIndex > 2 - 0.01 && _pageIndex < 2 + 0.99) then {
-		private _texture = [_vehicle] call vtx_uh60_mfd_fnc_tac_getMapTexture;
-		_vehicle setObjectTexture [_x - 15, _texture];
-		// systemChat str [_x - 8, _texture];
-	};
-} forEach [23, 24, 25, 26];
+params ["_vehicle","_textureMode","_mfdIndex"];
+
+_vehicle setVariable [format["vtx_uh60_mfd_%1_mapTextureMode", _mfdIndex], _textureMode, true];
+
+private _pageIndex = (getUserMFDValue _vehicle) # _mfdIndex;
+if (_pageIndex > 2 - 0.01 && _pageIndex < 2 + 0.99) then {
+	private _texture = [_vehicle, _mfdIndex] call vtx_uh60_mfd_fnc_tac_getMapTexture;
+	_vehicle setObjectTextureGlobal [_mfdIndex - 15, _texture];
+};


### PR DESCRIPTION
In the current stable version, in multiplayer, tac map textures do not get synced between players correctly. This results in map textures "resetting" after closing the map texture submenu most of the time. The texture is stuck.

**When merged this pull request will:**
- Fix multiplayer sync of tac map textures
- change the tac map texture system, so that all 4 MFD can display a different texture mode
- fix an unrelated logic error in the condition of _addons/uh60_mfd/functions/fnc_switchPage.sqf_, line 12

![20250422181516_1](https://github.com/user-attachments/assets/e1e5d761-b57b-4a98-b110-94f612e2a625)
