### PR TITLE
Fix FLIR waypoint creation sync in MP

### DIFF
--- a/addons/uh60_fms/functions/fnc_addWaypoint.sqf
+++ b/addons/uh60_fms/functions/fnc_addWaypoint.sqf
@@ -13,6 +13,6 @@ private _newWP = [_label, _location, _name];
 _microDagrWaypoints pushBack _newWP;
 ACE_player setVariable ["ace_microdagr_waypoints", _microDagrWaypoints];
 
-private _wp = group player addWaypoint [_newWP # 1, -1, (count waypoints group player), _name];
+private _wp = group player addWaypoint [_newWP # 1, -1, -1, _name];
 _wp setWaypointDescription _label;
 _wp setWaypointStatements ["false", ""];


### PR DESCRIPTION
In the stable version, in multiplayer, creating a waypoint through the flir system, does not get synced to to the other pilot, due to a error in the waypoint creation.

**When merged this pull request will:**
- Fix an error with the waypoint creation through the flir system
